### PR TITLE
Feature get books with designation id with tests

### DIFF
--- a/api/src/db/helpers/book_endpoint.rs
+++ b/api/src/db/helpers/book_endpoint.rs
@@ -13,11 +13,19 @@ pub fn find_books(query: BookQuery, db_state: &Db) -> Result<Vec<Book>, Error> {
             .into_boxed()
             .limit(query.limit.unwrap_or(20))
             .offset(query.offset.unwrap_or(0));
+
         let b = if let Some(p) = query.publisher_id {
             b.filter(publisher_id.eq(p))
         } else {
             b
         };
+
+        let b = if let Some(p) = query.designation_id {
+            b.filter(designation_id.eq(p))
+        } else {
+            b
+        };
+
         b.load::<Book>(&connection)
             .expect("can't load the list of books")
     };

--- a/api/src/db/tests/db_tests.rs
+++ b/api/src/db/tests/db_tests.rs
@@ -14,6 +14,7 @@ mod tests {
             limit: Some(2),
             offset: None,
             publisher_id: None,
+            designation_id: None,
         };
         let results = find_books(query, &db_state).unwrap();
 
@@ -24,17 +25,17 @@ mod tests {
     async fn retrieve_books_with_offset() {
         let db_state = test_db();
         let query = BookQuery {
-            limit: None,
+            limit: Some(2),
             offset: Some(1),
             publisher_id: None,
+            designation_id: None,
         };
-        let result: Vec<Book> = find_books(query, &db_state)
+        let result = find_books(query, &db_state)
             .unwrap()
             .into_iter()
-            .filter(|book| book.id == 1)
-            .collect();
+            .all(|book| book.id == 2 || book.id == 3);
 
-        assert!(result.is_empty());
+        assert!(result);
     }
 
     #[tokio::test]
@@ -44,14 +45,48 @@ mod tests {
             limit: None,
             offset: None,
             publisher_id: Some(2),
+            designation_id: None,
         };
-        let result: Vec<Book> = find_books(query, &db_state)
+        let result = find_books(query, &db_state)
             .unwrap()
             .into_iter()
-            .filter(|book| book.publisher_id == 2)
-            .collect();
+            .all(|book| book.publisher_id == 2);
 
-        assert!(!result.is_empty());
+        assert!(result);
+    }
+
+    #[tokio::test]
+    async fn retrieve_books_with_designation() {
+        let db_state = test_db();
+        let query = BookQuery {
+            limit: None,
+            offset: None,
+            publisher_id: None,
+            designation_id: Some(2),
+        };
+        let result = find_books(query, &db_state)
+            .unwrap()
+            .into_iter()
+            .all(|book| book.designation_id == 2);
+
+        assert!(result);
+    }
+
+    #[tokio::test]
+    async fn retrieve_books_with_queries() {
+        let db_state = test_db();
+        let query = BookQuery {
+            limit: None,
+            offset: None,
+            publisher_id: Some(2),
+            designation_id: Some(2),
+        };
+        let result = find_books(query, &db_state)
+            .unwrap()
+            .into_iter()
+            .all(|book| book.publisher_id == 2 && book.designation_id == 2);
+
+        assert!(result);
     }
 
     #[tokio::test]
@@ -74,108 +109,99 @@ mod tests {
     #[tokio::test]
     async fn retrieve_book() {
         let db_state = test_db();
-        let result: Vec<Book> = find_book(1, &db_state)
-            .into_iter()
-            .filter(|book| book.id == 1)
-            .collect();
+        let result = find_book(1, &db_state).into_iter().all(|book| book.id == 1);
 
-        assert!(!result.is_empty());
+        assert!(result);
     }
 
     #[tokio::test]
     async fn retrieve_book_designations() {
         let db_state = test_db();
-        let result: Vec<Designation> = find_book_designations(1, &db_state)
+        let result = find_book_designations(1, &db_state)
             .unwrap()
             .into_iter()
-            .filter(|designation| designation.name == "DH")
-            .collect();
+            .all(|designation| designation.name == "DH");
 
-        assert!(!result.is_empty());
+        assert!(result);
     }
 
     #[tokio::test]
     async fn retrieve_book_publishers() {
         let db_state = test_db();
-        let result: Vec<Publisher> = find_book_publishers(1, &db_state)
+        let result = find_book_publishers(1, &db_state)
             .unwrap()
             .into_iter()
-            .filter(|publisher| publisher.id == 1)
-            .collect();
+            .all(|publisher| publisher.id == 1);
 
-        assert!(!result.is_empty());
+        assert!(result);
     }
 
     #[tokio::test]
     async fn retrieve_book_authors() {
         let db_state = test_db();
-        let result: Vec<Person> = find_book_authors(1, &db_state)
+        let result = find_book_authors(1, &db_state)
             .unwrap()
             .into_iter()
-            .filter(|person| person.id == 1)
-            .collect();
+            .all(|person| person.id == 1);
 
-        assert!(!result.is_empty());
+        assert!(result);
     }
 
     #[tokio::test]
     async fn retrieve_book_languages() {
         let db_state = test_db();
-        let result: Vec<Language> = find_book_languages(1, &db_state)
+        let result = find_book_languages(1, &db_state)
             .unwrap()
             .into_iter()
-            .filter(|language| language.language_name == "English")
-            .collect();
+            .all(|language| language.language_name == "English");
 
-        assert!(!result.is_empty());
+        assert!(result);
     }
 
     #[tokio::test]
     async fn retrieve_book_physical_sizes() {
         let db_state = test_db();
-        let result: Vec<PhysicalSize> = find_book_physical_sizes(1, &db_state)
+        let result = find_book_physical_sizes(1, &db_state)
             .unwrap()
             .into_iter()
-            .filter(|physical_size| physical_size.id == 1)
-            .collect();
+            .all(|physical_size| physical_size.id == 1);
 
-        assert!(!result.is_empty());
+        assert!(result);
     }
 
     #[tokio::test]
     async fn retrieve_book_subject_areas() {
         let db_state = test_db();
-        let result: Vec<SubjectArea> = find_book_subject_areas(3, &db_state)
+        let result = find_book_subject_areas(3, &db_state)
             .unwrap()
             .into_iter()
-            .filter(|subject_area| subject_area.name == "Computer Science")
-            .collect();
+            .all(|subject_area| {
+                subject_area.name == "Computer Science" || subject_area.name == "Philosophy"
+            });
 
-        assert!(!result.is_empty());
+        assert!(result);
     }
 
     #[tokio::test]
     async fn retrieve_book_copies() {
         let db_state = test_db();
-        let result: Vec<Copy> = find_book_copies(1, &db_state)
+        let result = find_book_copies(1, &db_state)
             .unwrap()
             .into_iter()
-            .filter(|copies| copies.code_identifier_copy_id == Some(1))
-            .collect();
+            .all(|copies| copies.code_identifier_copy_id == Some(1));
 
-        assert!(!result.is_empty());
+        assert!(result);
     }
 
     #[tokio::test]
     async fn retrieve_book_status() {
         let db_state = test_db();
-        let result: Vec<Status> = find_book_status(1, &db_state)
+        let result = find_book_status(1, &db_state)
             .unwrap()
             .into_iter()
-            .filter(|status| status.available)
-            .collect();
+            .all(|status| status.available);
 
-        assert!(!result.is_empty());
+        assert!(result);
     }
 
     #[tokio::test]
@@ -189,13 +215,12 @@ mod tests {
     #[tokio::test]
     async fn retrieve_designation() {
         let db_state = test_db();
-        let result: Vec<Designation> = find_designation_by_id(2, &db_state)
+        let result = find_designation_by_id(2, &db_state)
             .unwrap()
             .into_iter()
-            .filter(|designation| designation.name == "SE")
-            .collect();
+            .all(|designation| designation.name == "SE");
 
-        assert_eq!(result.len(), 1);
+        assert!(result);
     }
 
     #[tokio::test]
@@ -209,13 +234,12 @@ mod tests {
     #[tokio::test]
     async fn retrieve_publisher() {
         let db_state = test_db();
-        let result: Vec<Publisher> = find_publisher_by_id(3, &db_state)
+        let result = find_publisher_by_id(3, &db_state)
             .unwrap()
             .into_iter()
-            .filter(|publisher| publisher.name == "FREEMAN and Company")
-            .collect();
+            .all(|publisher| publisher.name == "FREEMAN and Company");
 
-        assert!(!result.is_empty());
+        assert!(result);
     }
 
     #[tokio::test]
@@ -240,13 +264,12 @@ mod tests {
     #[tokio::test]
     async fn retrieve_author() {
         let db_state = test_db();
-        let result: Vec<Person> = find_author_by_id(1, &db_state)
+        let result = find_author_by_id(1, &db_state)
             .unwrap()
             .into_iter()
-            .filter(|author| author.last_name == Some("Goldhill".to_string()))
-            .collect();
+            .all(|author| author.last_name == Some("Goldhill".to_string()));
 
-        assert!(!result.is_empty());
+        assert!(result);
     }
 
     #[tokio::test]
@@ -260,13 +283,12 @@ mod tests {
     #[tokio::test]
     async fn retrieve_language() {
         let db_state = test_db();
-        let result: Vec<Language> = find_language_by_id(1, &db_state)
+        let result = find_language_by_id(1, &db_state)
             .unwrap()
             .into_iter()
-            .filter(|language| language.language_name == "English")
-            .collect();
+            .all(|language| language.language_name == "English");
 
-        assert!(!result.is_empty());
+        assert!(result);
     }
 
     #[tokio::test]
@@ -280,13 +302,12 @@ mod tests {
     #[tokio::test]
     async fn retrieve_physical_size() {
         let db_state = test_db();
-        let result: Vec<PhysicalSize> = find_physical_size_by_id(1, &db_state)
+        let result = find_physical_size_by_id(1, &db_state)
             .unwrap()
             .into_iter()
-            .filter(|physical_size| physical_size.name == "normal")
-            .collect();
+            .all(|physical_size| physical_size.name == "normal");
 
-        assert!(!result.is_empty());
+        assert!(result);
     }
 
     #[tokio::test]
@@ -300,12 +321,11 @@ mod tests {
     #[tokio::test]
     async fn retrieve_subject_area() {
         let db_state = test_db();
-        let result: Vec<SubjectArea> = find_subject_area_by_id(1, &db_state)
+        let result = find_subject_area_by_id(1, &db_state)
             .unwrap()
             .into_iter()
-            .filter(|subject_area| subject_area.name == "Health Care")
-            .collect();
+            .all(|subject_area| subject_area.name == "Health Care");
 
-        assert!(!result.is_empty());
+        assert!(result);
     }
 }

--- a/api/src/query_models/book.rs
+++ b/api/src/query_models/book.rs
@@ -8,6 +8,7 @@ pub struct BookQuery {
     pub limit: Option<i64>,
     pub offset: Option<i64>,
     pub publisher_id: Option<i32>,
+    pub designation_id: Option<i32>,
 }
 
 #[derive(Serialize, Deserialize, AsChangeset)]

--- a/api/tests/book_endpoint_tests.rs
+++ b/api/tests/book_endpoint_tests.rs
@@ -29,6 +29,7 @@ mod tests {
                 limit: Some(1),
                 offset: None,
                 publisher_id: None,
+                designation_id: None,
             })
             .reply(&filter)
             .await;
@@ -47,6 +48,7 @@ mod tests {
                 limit: None,
                 offset: Some(1),
                 publisher_id: None,
+                designation_id: None,
             })
             .reply(&filter)
             .await;
@@ -65,6 +67,7 @@ mod tests {
                 limit: None,
                 offset: None,
                 publisher_id: Some(2),
+                designation_id: None,
             })
             .reply(&filter)
             .await;


### PR DESCRIPTION
- This adds feature to retrieve books by `designation_id`. 
- This also adds tests to cover the request with multiple queries. 
- Test logic has been changed from `filter` to `all` to cover multiple queries and to fix the bug when test function could retrieve incorrect results before filtering.