### PR TITLE
Add Cargo.lock to continuous delivery pipeline

### DIFF
--- a/.github/workflows/cd-dev-api.yml
+++ b/.github/workflows/cd-dev-api.yml
@@ -4,6 +4,7 @@ on:
             - 'master'
         paths:
             - 'api/**'
+            - 'Cargo.lock'
 
 jobs:
     build:

--- a/.github/workflows/cd-dev-book.yml
+++ b/.github/workflows/cd-dev-book.yml
@@ -4,6 +4,7 @@ on:
             - 'master'
         paths:
             - 'book/**'
+            - 'Cargo.lock'
 
 jobs:
     build:

--- a/.github/workflows/cd-dev-borrow.yml
+++ b/.github/workflows/cd-dev-borrow.yml
@@ -4,6 +4,7 @@ on:
             - 'master'
         paths:
             - 'borrow/**'
+            - 'Cargo.lock'
 
 jobs:
     build:

--- a/.github/workflows/cd-dev-identity.yml
+++ b/.github/workflows/cd-dev-identity.yml
@@ -4,6 +4,7 @@ on:
             - 'master'
         paths:
             - 'identity/**'
+            - 'Cargo.lock'
 
 jobs:
     build:

--- a/.github/workflows/cd-dev-notification.yml
+++ b/.github/workflows/cd-dev-notification.yml
@@ -4,6 +4,7 @@ on:
             - 'master'
         paths:
             - 'notification/**'
+            - 'Cargo.lock'
 
 jobs:
     build:


### PR DESCRIPTION
This adds `Cargo.lock` to the paths of all continuous delivery workflows. The fact that we do not have patch versions any more in the `Cargo.toml` files leads to the fact that Dependabot updates only update the `Cargo.lock` file. This will not run the respective workflows for pushing an updated version of the applications.