### PR TITLE
Revert "Bump tokio from 0.2.22 to 0.3.0"

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -32,7 +32,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tarpc",
- "tokio 0.3.0",
+ "tokio",
  "tokio-serde",
  "warp",
 ]
@@ -122,7 +122,7 @@ dependencies = [
  "once_cell",
  "serde",
  "tarpc",
- "tokio 0.3.0",
+ "tokio",
  "tokio-serde",
 ]
 
@@ -140,7 +140,7 @@ dependencies = [
  "once_cell",
  "serde",
  "tarpc",
- "tokio 0.3.0",
+ "tokio",
  "tokio-serde",
 ]
 
@@ -530,7 +530,7 @@ dependencies = [
  "http",
  "indexmap",
  "slab",
- "tokio 0.2.22",
+ "tokio",
  "tokio-util",
  "tracing",
 ]
@@ -641,7 +641,7 @@ dependencies = [
  "itoa",
  "pin-project",
  "socket2",
- "tokio 0.2.22",
+ "tokio",
  "tower-service",
  "tracing",
  "want",
@@ -656,7 +656,7 @@ dependencies = [
  "bytes",
  "hyper",
  "native-tls",
- "tokio 0.2.22",
+ "tokio",
  "tokio-tls",
 ]
 
@@ -677,7 +677,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tarpc",
- "tokio 0.3.0",
+ "tokio",
  "tokio-serde",
 ]
 
@@ -846,15 +846,14 @@ dependencies = [
 ]
 
 [[package]]
-name = "mio"
-version = "0.7.3"
+name = "mio-named-pipes"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e53a6ea5f38c0a48ca42159868c6d8e1bd56c0451238856cc08d58563643bdc3"
+checksum = "0840c1c50fd55e521b247f949c241c9997709f23bd7f023b9762cd561e935656"
 dependencies = [
- "libc",
  "log",
+ "mio",
  "miow 0.3.5",
- "ntapi",
  "winapi 0.3.9",
 ]
 
@@ -866,7 +865,7 @@ checksum = "afcb699eb26d4332647cc848492bbc15eafb26f08d0304550d5aa1f612e066f0"
 dependencies = [
  "iovec",
  "libc",
- "mio 0.6.22",
+ "mio",
 ]
 
 [[package]]
@@ -952,17 +951,8 @@ dependencies = [
  "once_cell",
  "serde",
  "tarpc",
- "tokio 0.3.0",
+ "tokio",
  "tokio-serde",
-]
-
-[[package]]
-name = "ntapi"
-version = "0.3.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a31937dea023539c72ddae0e3571deadc1414b300483fa7aaec176168cfa9d2"
-dependencies = [
- "winapi 0.3.9",
 ]
 
 [[package]]
@@ -1621,7 +1611,7 @@ dependencies = [
  "serde",
  "static_assertions",
  "tarpc-plugins",
- "tokio 0.2.22",
+ "tokio",
  "tokio-serde",
  "tokio-util",
 ]
@@ -1699,27 +1689,10 @@ dependencies = [
  "lazy_static",
  "libc",
  "memchr",
- "mio 0.6.22",
+ "mio",
+ "mio-named-pipes",
  "mio-uds",
- "pin-project-lite",
- "slab",
-]
-
-[[package]]
-name = "tokio"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7137dbb0abee577362ccdc7df21605cfcbb949243aeab47dac9ea6ef7d830e21"
-dependencies = [
- "bytes",
- "fnv",
- "futures-core",
- "lazy_static",
- "libc",
- "memchr",
- "mio 0.7.3",
  "num_cpus",
- "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
  "slab",
@@ -1729,9 +1702,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "0.3.0"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d48caa7b66c7a6ec943edf78d21a594fbeb24e536c781da67d5c32edec54103f"
+checksum = "f0c3acc6aa564495a0f2e1d59fab677cd7f81a19994cfc7f3ad0e64301560389"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1759,7 +1732,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a70f4fcd7b3b24fb194f837560168208f669ca8cb70d0c4b862944452396343"
 dependencies = [
  "native-tls",
- "tokio 0.2.22",
+ "tokio",
 ]
 
 [[package]]
@@ -1771,7 +1744,7 @@ dependencies = [
  "futures-util",
  "log",
  "pin-project",
- "tokio 0.2.22",
+ "tokio",
  "tungstenite",
 ]
 
@@ -1786,7 +1759,7 @@ dependencies = [
  "futures-sink",
  "log",
  "pin-project-lite",
- "tokio 0.2.22",
+ "tokio",
 ]
 
 [[package]]
@@ -1970,7 +1943,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_urlencoded",
- "tokio 0.2.22",
+ "tokio",
  "tokio-tungstenite",
  "tower-service",
  "tracing",

--- a/api/Cargo.toml
+++ b/api/Cargo.toml
@@ -18,6 +18,6 @@ once_cell = "1.4"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 tarpc = { version = "0.22", features = ["full"] }
-tokio = { version = "0.3", features = ["full"] }
+tokio = { version = "0.2", features = ["full"] }
 tokio-serde = { version = "0.6", features = ["json"] }
 warp = "0.2"

--- a/book/Cargo.toml
+++ b/book/Cargo.toml
@@ -15,5 +15,5 @@ log = "0.4"
 once_cell = "1.4"
 serde = { version = "1.0", features = ["derive"] }
 tarpc = { version = "0.22", features = ["full"] }
-tokio = { version = "0.3", features = ["full"] }
+tokio = { version = "0.2", features = ["full"] }
 tokio-serde = { version = "0.6", features = ["json"] }

--- a/borrow/Cargo.toml
+++ b/borrow/Cargo.toml
@@ -15,5 +15,5 @@ log = "0.4"
 once_cell = "1.4"
 serde = { version = "1.0", features = ["derive"] }
 tarpc = { version = "0.22", features = ["full"] }
-tokio = { version = "0.3", features = ["full"] }
+tokio = { version = "0.2", features = ["full"] }
 tokio-serde = { version = "0.6", features = ["json"] }

--- a/identity/Cargo.toml
+++ b/identity/Cargo.toml
@@ -22,5 +22,5 @@ once_cell = "1.4"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 tarpc = { version = "0.22", features = ["full"] }
-tokio = { version = "0.3", features = ["full"] }
+tokio = { version = "0.2", features = ["full"] }
 tokio-serde = { version = "0.6", features = ["json"] }

--- a/notification/Cargo.toml
+++ b/notification/Cargo.toml
@@ -15,5 +15,5 @@ log = "0.4"
 once_cell = "1.4"
 serde = { version = "1.0", features = ["derive"] }
 tarpc = { version = "0.22", features = ["full"] }
-tokio = { version = "0.3", features = ["full"] }
+tokio = { version = "0.2", features = ["full"] }
 tokio-serde = { version = "0.6", features = ["json"] }


### PR DESCRIPTION
Tokio causes a panic, because some of our other dependencies still have version `0.2`, which is incompatible with `0.3`.

This reverts commit 4cc4235544b433a180f3e7b77d5cf1f713e45ed3.