### PR TITLE
Make default microservice server ports unique

### DIFF
--- a/book/src/config.rs
+++ b/book/src/config.rs
@@ -21,7 +21,7 @@ pub struct Configuration {
     #[envconfig(from = "RPC_HOST_IP", default = "127.0.0.1")]
     rpc_host_ip: IpAddr,
 
-    #[envconfig(from = "RPC_HOST_PORT", default = "8080")]
+    #[envconfig(from = "RPC_HOST_PORT", default = "8082")]
     rpc_host_port: u16,
 }
 

--- a/borrow/src/config.rs
+++ b/borrow/src/config.rs
@@ -21,7 +21,7 @@ pub struct Configuration {
     #[envconfig(from = "RPC_HOST_IP", default = "127.0.0.1")]
     rpc_host_ip: IpAddr,
 
-    #[envconfig(from = "RPC_HOST_PORT", default = "8080")]
+    #[envconfig(from = "RPC_HOST_PORT", default = "8083")]
     rpc_host_port: u16,
 }
 

--- a/notification/src/config.rs
+++ b/notification/src/config.rs
@@ -21,7 +21,7 @@ pub struct Configuration {
     #[envconfig(from = "RPC_HOST_IP", default = "127.0.0.1")]
     rpc_host_ip: IpAddr,
 
-    #[envconfig(from = "RPC_HOST_PORT", default = "8080")]
+    #[envconfig(from = "RPC_HOST_PORT", default = "8084")]
     rpc_host_port: u16,
 }
 


### PR DESCRIPTION
After this change the ports will be as follows:

* `api` 8080
* `identity` 8081
* `book` 8082
* `borrow` 8083
* `notification` 8084