### PR TITLE
api: Unify error handling

### DIFF
--- a/api/src/endpoints/identity.rs
+++ b/api/src/endpoints/identity.rs
@@ -1,27 +1,17 @@
-use http::status::StatusCode;
-use serde::Serialize;
 use std::{collections::HashMap, convert::Infallible};
 use tarpc::context;
 use warp::Reply;
 
-#[derive(Serialize)]
-struct ErrorMessage<'a> {
-    code: u32,
-    message: &'a str,
-}
+use identity_rpc_service::Error;
+
+use crate::response;
 
 pub async fn get_oauth_client_identifier() -> Result<impl Reply, Infallible> {
     let mut client = match crate::rpc::identity_client().await {
         Ok(val) => val,
         Err(e) => {
             log::error!("Identity service error: {}", e);
-            return Ok(warp::reply::with_status(
-                warp::reply::json(&ErrorMessage {
-                    code: 500,
-                    message: "INTERNAL_SERVER_ERROR",
-                }),
-                StatusCode::INTERNAL_SERVER_ERROR,
-            ));
+            return Ok(response::internal_server_error());
         }
     };
 
@@ -29,52 +19,16 @@ pub async fn get_oauth_client_identifier() -> Result<impl Reply, Infallible> {
         .oauth_client_identifier(context::current())
         .await
         .map(|x| match x {
-            Ok(val) => warp::reply::with_status(warp::reply::json(&val), StatusCode::OK),
-            Err(identity_rpc_service::Error::InternalError) => warp::reply::with_status(
-                warp::reply::json(&ErrorMessage {
-                    code: 500,
-                    message: "INTERNAL_SERVER_ERROR",
-                }),
-                StatusCode::INTERNAL_SERVER_ERROR,
-            ),
-            Err(identity_rpc_service::Error::NotFound) => warp::reply::with_status(
-                warp::reply::json(&ErrorMessage {
-                    code: 404,
-                    message: "NOT_FOUND",
-                }),
-                StatusCode::NOT_FOUND,
-            ),
-            Err(identity_rpc_service::Error::AlreadyExists) => warp::reply::with_status(
-                warp::reply::json(&ErrorMessage {
-                    code: 400,
-                    message: "ALREADY_EXISTS",
-                }),
-                StatusCode::BAD_REQUEST,
-            ),
-            Err(identity_rpc_service::Error::InvalidInput) => warp::reply::with_status(
-                warp::reply::json(&ErrorMessage {
-                    code: 400,
-                    message: "INVALID_INPUT",
-                }),
-                StatusCode::BAD_REQUEST,
-            ),
-            Err(identity_rpc_service::Error::InvalidData) => warp::reply::with_status(
-                warp::reply::json(&ErrorMessage {
-                    code: 400,
-                    message: "INVALID_DATA",
-                }),
-                StatusCode::BAD_REQUEST,
-            ),
+            Ok(val) => response::okay_with_json(&val),
+            Err(Error::InternalError) => response::internal_server_error(),
+            Err(Error::NotFound) => response::not_found(),
+            Err(Error::AlreadyExists) => response::bad_request("ALREADY_EXISTS"),
+            Err(Error::InvalidInput) => response::bad_request("INVALID_INPUT"),
+            Err(Error::InvalidData) => response::bad_request("INVALID_DATA"),
         })
         .or_else(|e| {
             log::error!("Identity service error: {}", e);
-            Ok(warp::reply::with_status(
-                warp::reply::json(&ErrorMessage {
-                    code: 500,
-                    message: "INTERNAL_SERVER_ERROR",
-                }),
-                StatusCode::INTERNAL_SERVER_ERROR,
-            ))
+            Ok(response::internal_server_error())
         })
 }
 
@@ -85,13 +39,7 @@ pub async fn create_oauth_authentication(
         Ok(val) => val,
         Err(e) => {
             log::error!("Identity service error: {}", e);
-            return Ok(warp::reply::with_status(
-                warp::reply::json(&ErrorMessage {
-                    code: 500,
-                    message: "INTERNAL_SERVER_ERROR",
-                }),
-                StatusCode::INTERNAL_SERVER_ERROR,
-            ));
+            return Ok(response::internal_server_error());
         }
     };
 
@@ -99,52 +47,16 @@ pub async fn create_oauth_authentication(
         .oauth_authentication(context::current(), body["code"].clone())
         .await
         .map(|x| match x {
-            Ok(val) => warp::reply::with_status(warp::reply::json(&val), StatusCode::OK),
-            Err(identity_rpc_service::Error::InternalError) => warp::reply::with_status(
-                warp::reply::json(&ErrorMessage {
-                    code: 500,
-                    message: "INTERNAL_SERVER_ERROR",
-                }),
-                StatusCode::INTERNAL_SERVER_ERROR,
-            ),
-            Err(identity_rpc_service::Error::NotFound) => warp::reply::with_status(
-                warp::reply::json(&ErrorMessage {
-                    code: 404,
-                    message: "NOT_FOUND",
-                }),
-                StatusCode::NOT_FOUND,
-            ),
-            Err(identity_rpc_service::Error::AlreadyExists) => warp::reply::with_status(
-                warp::reply::json(&ErrorMessage {
-                    code: 400,
-                    message: "ALREADY_EXISTS",
-                }),
-                StatusCode::BAD_REQUEST,
-            ),
-            Err(identity_rpc_service::Error::InvalidInput) => warp::reply::with_status(
-                warp::reply::json(&ErrorMessage {
-                    code: 400,
-                    message: "INVALID_INPUT",
-                }),
-                StatusCode::BAD_REQUEST,
-            ),
-            Err(identity_rpc_service::Error::InvalidData) => warp::reply::with_status(
-                warp::reply::json(&ErrorMessage {
-                    code: 400,
-                    message: "INVALID_DATA",
-                }),
-                StatusCode::BAD_REQUEST,
-            ),
+            Ok(val) => response::okay_with_json(&val),
+            Err(Error::InternalError) => response::internal_server_error(),
+            Err(Error::NotFound) => response::not_found(),
+            Err(Error::AlreadyExists) => response::bad_request("ALREADY_EXISTS"),
+            Err(Error::InvalidInput) => response::bad_request("INVALID_INPUT"),
+            Err(Error::InvalidData) => response::bad_request("INVALID_DATA"),
         })
         .or_else(|e| {
             log::error!("Identity service error: {}", e);
-            Ok(warp::reply::with_status(
-                warp::reply::json(&ErrorMessage {
-                    code: 500,
-                    message: "INTERNAL_SERVER_ERROR",
-                }),
-                StatusCode::INTERNAL_SERVER_ERROR,
-            ))
+            Ok(response::internal_server_error())
         })
 }
 
@@ -155,13 +67,7 @@ pub async fn get_session_info(
         Ok(val) => val,
         Err(e) => {
             log::error!("Identity service error: {}", e);
-            return Ok(warp::reply::with_status(
-                warp::reply::json(&ErrorMessage {
-                    code: 500,
-                    message: "INTERNAL_SERVER_ERROR",
-                }),
-                StatusCode::INTERNAL_SERVER_ERROR,
-            ));
+            return Ok(response::internal_server_error());
         }
     };
 
@@ -169,51 +75,15 @@ pub async fn get_session_info(
         .session_info(context::current(), session.token)
         .await
         .map(|x| match x {
-            Ok(val) => warp::reply::with_status(warp::reply::json(&val), StatusCode::OK),
-            Err(identity_rpc_service::Error::InternalError) => warp::reply::with_status(
-                warp::reply::json(&ErrorMessage {
-                    code: 500,
-                    message: "INTERNAL_SERVER_ERROR",
-                }),
-                StatusCode::INTERNAL_SERVER_ERROR,
-            ),
-            Err(identity_rpc_service::Error::NotFound) => warp::reply::with_status(
-                warp::reply::json(&ErrorMessage {
-                    code: 404,
-                    message: "NOT_FOUND",
-                }),
-                StatusCode::NOT_FOUND,
-            ),
-            Err(identity_rpc_service::Error::AlreadyExists) => warp::reply::with_status(
-                warp::reply::json(&ErrorMessage {
-                    code: 400,
-                    message: "ALREADY_EXISTS",
-                }),
-                StatusCode::BAD_REQUEST,
-            ),
-            Err(identity_rpc_service::Error::InvalidInput) => warp::reply::with_status(
-                warp::reply::json(&ErrorMessage {
-                    code: 400,
-                    message: "INVALID_INPUT",
-                }),
-                StatusCode::BAD_REQUEST,
-            ),
-            Err(identity_rpc_service::Error::InvalidData) => warp::reply::with_status(
-                warp::reply::json(&ErrorMessage {
-                    code: 400,
-                    message: "INVALID_DATA",
-                }),
-                StatusCode::BAD_REQUEST,
-            ),
+            Ok(val) => response::okay_with_json(&val),
+            Err(Error::InternalError) => response::internal_server_error(),
+            Err(Error::NotFound) => response::not_found(),
+            Err(Error::AlreadyExists) => response::bad_request("ALREADY_EXISTS"),
+            Err(Error::InvalidInput) => response::bad_request("INVALID_INPUT"),
+            Err(Error::InvalidData) => response::bad_request("INVALID_DATA"),
         })
         .or_else(|e| {
             log::error!("Identity service communication error: {}", e);
-            Ok(warp::reply::with_status(
-                warp::reply::json(&ErrorMessage {
-                    code: 500,
-                    message: "INTERNAL_SERVER_ERROR",
-                }),
-                StatusCode::INTERNAL_SERVER_ERROR,
-            ))
+            Ok(response::internal_server_error())
         })
 }

--- a/api/src/lib.rs
+++ b/api/src/lib.rs
@@ -4,6 +4,7 @@ use warp::{filters::BoxedFilter, Reply};
 mod config;
 mod endpoints;
 mod middleware;
+mod response;
 mod router;
 mod rpc;
 

--- a/api/src/response.rs
+++ b/api/src/response.rs
@@ -1,0 +1,63 @@
+use http::StatusCode;
+use serde::Serialize;
+use warp::reply::{Json, WithStatus};
+
+#[derive(Clone, Serialize)]
+struct ErrorMessage<'a> {
+    pub code: u32,
+    pub msg: &'a str,
+}
+
+/// `200` OK
+pub fn okay_with_json(json: &impl Serialize) -> WithStatus<Json> {
+    warp::reply::with_status(warp::reply::json(json), StatusCode::OK)
+}
+
+/// `400` Bad Request
+pub fn bad_request(msg: &str) -> WithStatus<Json> {
+    warp::reply::with_status(
+        warp::reply::json(&ErrorMessage { code: 400, msg }),
+        StatusCode::BAD_REQUEST,
+    )
+}
+
+/// `401` Unauthorized
+pub fn unauthorized(msg: &str) -> WithStatus<Json> {
+    warp::reply::with_status(
+        warp::reply::json(&ErrorMessage { code: 401, msg }),
+        StatusCode::UNAUTHORIZED,
+    )
+}
+
+/// `404` Not Found
+pub fn not_found() -> WithStatus<Json> {
+    warp::reply::with_status(
+        warp::reply::json(&ErrorMessage {
+            code: 404,
+            msg: "NOT_FOUND",
+        }),
+        StatusCode::NOT_FOUND,
+    )
+}
+
+/// `405` Method Not Allowed
+pub fn method_not_allowed() -> WithStatus<Json> {
+    warp::reply::with_status(
+        warp::reply::json(&ErrorMessage {
+            code: 405,
+            msg: "METHOD_NOT_ALLOWED",
+        }),
+        StatusCode::METHOD_NOT_ALLOWED,
+    )
+}
+
+/// `500` Internal Server Error
+pub fn internal_server_error() -> WithStatus<Json> {
+    warp::reply::with_status(
+        warp::reply::json(&ErrorMessage {
+            code: 500,
+            msg: "INTERNAL_SERVER_ERROR",
+        }),
+        StatusCode::INTERNAL_SERVER_ERROR,
+    )
+}


### PR DESCRIPTION
* add `mod error`: contains helper functions for warp error replies
* Adapt `enpoints::identity`, `middleware` to error module