### PR TITLE
Add unique roles migration for identity microservice

### DIFF
--- a/identity/migrations/2020-11-02-210000_add_unique_roles/down.sql
+++ b/identity/migrations/2020-11-02-210000_add_unique_roles/down.sql
@@ -1,0 +1,4 @@
+ALTER TABLE roles DROP CONSTRAINT roles_name_key;
+DELETE FROM roles WHERE name='User';
+DELETE FROM roles WHERE name='Manager';
+DELETE FROM roles WHERE name='Administrator';

--- a/identity/migrations/2020-11-02-210000_add_unique_roles/up.sql
+++ b/identity/migrations/2020-11-02-210000_add_unique_roles/up.sql
@@ -1,0 +1,4 @@
+ALTER TABLE roles ADD UNIQUE (name);
+INSERT INTO roles (name, access_manage_books, access_manage_roles) VALUES ('User', False, False);
+INSERT INTO roles (name, access_manage_books, access_manage_roles) VALUES ('Manager', True, False);
+INSERT INTO roles (name, access_manage_books, access_manage_roles) VALUES ('Administrator', True, True);


### PR DESCRIPTION
The migration for the identity microservice had the roles missing, which are required to successfully run the service. This adds the roles and also makes the role names unique to prevent a future name clash.