### PR TITLE
Helpers: Add `enum Error`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -587,6 +587,7 @@ dependencies = [
  "diesel",
  "diesel_migrations",
  "log",
+ "serde",
 ]
 
 [[package]]

--- a/book/src/db/models.rs
+++ b/book/src/db/models.rs
@@ -1,13 +1,6 @@
 use serde::{Deserialize, Serialize};
 
-#[derive(Clone, Debug, Deserialize, Serialize)]
-pub enum Error {
-    AlreadyExists,
-    InternalError,
-    InvalidData,
-    InvalidInput,
-    NotFound,
-}
+pub use helpers::rpc::Error;
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Book {

--- a/helpers/Cargo.toml
+++ b/helpers/Cargo.toml
@@ -10,3 +10,4 @@ edition = "2018"
 diesel = { version = "1.4", features = ["postgres", "r2d2"] }
 diesel_migrations = "1.4"
 log = "0.4"
+serde = { version = "1.0", features = ["derive"] }

--- a/helpers/src/lib.rs
+++ b/helpers/src/lib.rs
@@ -1,1 +1,2 @@
 pub mod db;
+pub mod rpc;

--- a/helpers/src/rpc.rs
+++ b/helpers/src/rpc.rs
@@ -1,0 +1,11 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+/// Error type to be used in-between api and rpc-services
+pub enum Error {
+    AlreadyExists,
+    InternalError,
+    InvalidData,
+    InvalidInput,
+    NotFound,
+}

--- a/identity/src/rpc/service.rs
+++ b/identity/src/rpc/service.rs
@@ -1,3 +1,7 @@
+use serde::{Deserialize, Serialize};
+
+pub use helpers::rpc::Error;
+
 #[tarpc::service]
 pub trait IdentityService {
     async fn get_user(user_id: u32) -> Result<User, Error>;
@@ -19,17 +23,6 @@ pub trait IdentityService {
     async fn oauth_client_identifier() -> Result<OauthClientIdentifier, Error>;
     async fn oauth_authentication(code: AuthorizationCode) -> Result<SessionToken, Error>;
     async fn session_info(token: String) -> Result<SessionInfo, Error>;
-}
-
-use serde::{Deserialize, Serialize};
-
-#[derive(Debug, Deserialize, Serialize)]
-pub enum Error {
-    NotFound,
-    AlreadyExists,
-    InvalidInput,
-    InvalidData,
-    InternalError,
 }
 
 #[derive(Debug, Deserialize, Serialize)]


### PR DESCRIPTION
Error type to be used in-between api and rpc-services