### PR TITLE
book: Restructure lib

### DIFF
--- a/book/src/db/models.rs
+++ b/book/src/db/models.rs
@@ -1,8 +1,1 @@
-use serde::{Deserialize, Serialize};
 
-pub use helpers::rpc::Error;
-
-#[derive(Clone, Debug, Deserialize, Serialize)]
-pub struct Book {
-    pub id: i32,
-}

--- a/book/src/lib.rs
+++ b/book/src/lib.rs
@@ -1,33 +1,10 @@
 use diesel::prelude::*;
 use diesel::r2d2::{ConnectionManager, Pool};
-use futures::{future, prelude::*};
 use once_cell::sync::OnceCell;
-use std::io;
-use std::net::SocketAddr;
-use tarpc::server::{self, Channel, Handler};
-use tokio_serde::formats::Json;
 
-pub mod db;
-pub mod rpc;
+mod db;
+mod rpc;
 
-use crate::rpc::{server::BookServer, service::BookService};
+pub use crate::rpc::*;
 
 pub static DB: OnceCell<Pool<ConnectionManager<PgConnection>>> = OnceCell::new();
-
-pub async fn rpc_server(addr: &SocketAddr) -> io::Result<(impl Future<Output = ()>, SocketAddr)> {
-    let incoming = tarpc::serde_transport::tcp::listen(addr, Json::default).await?;
-    let addr = incoming.local_addr();
-
-    let fut = incoming
-        .filter_map(|r| future::ready(r.ok()))
-        .map(server::BaseChannel::with_defaults)
-        .max_channels_per_key(1, |t| t.as_ref().peer_addr().unwrap().ip())
-        .map(|channel| {
-            let server = BookServer(channel.as_ref().as_ref().peer_addr().unwrap());
-            channel.respond_with(server.serve()).execute()
-        })
-        .buffer_unordered(10)
-        .for_each(|_| async {});
-
-    Ok((fut, addr))
-}

--- a/book/src/rpc/mod.rs
+++ b/book/src/rpc/mod.rs
@@ -1,2 +1,29 @@
+use futures::{future, prelude::*};
+use std::io;
+use std::net::SocketAddr;
+use tarpc::server::{BaseChannel, Channel, Handler};
+use tokio_serde::formats::Json;
+
+pub mod models;
 pub mod server;
 pub mod service;
+
+use super::{server::BookServer, service::BookService};
+
+pub async fn rpc_server(addr: &SocketAddr) -> io::Result<(impl Future<Output = ()>, SocketAddr)> {
+    let incoming = tarpc::serde_transport::tcp::listen(addr, Json::default).await?;
+    let addr = incoming.local_addr();
+
+    let fut = incoming
+        .filter_map(|r| future::ready(r.ok()))
+        .map(BaseChannel::with_defaults)
+        .max_channels_per_key(1, |t| t.as_ref().peer_addr().unwrap().ip())
+        .map(|channel| {
+            let server = BookServer(channel.as_ref().as_ref().peer_addr().unwrap());
+            channel.respond_with(server.serve()).execute()
+        })
+        .buffer_unordered(10)
+        .for_each(|_| async {});
+
+    Ok((fut, addr))
+}

--- a/book/src/rpc/models.rs
+++ b/book/src/rpc/models.rs
@@ -1,0 +1,9 @@
+use serde::{Deserialize, Serialize};
+
+/// Error type returned to API
+pub use helpers::rpc::Error;
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct Book {
+    pub id: i32,
+}

--- a/book/src/rpc/server.rs
+++ b/book/src/rpc/server.rs
@@ -1,8 +1,7 @@
 use std::net::SocketAddr;
 use tarpc::context;
 
-use crate::db::models::{Book, Error};
-
+use super::models::{Book, Error};
 use super::service::BookService;
 
 #[derive(Clone)]

--- a/book/src/rpc/service.rs
+++ b/book/src/rpc/service.rs
@@ -1,4 +1,4 @@
-use crate::db::models::{Book, Error};
+use super::models::{Book, Error};
 
 #[tarpc::service]
 pub trait BookService {


### PR DESCRIPTION
* mv `db::models::*` to `rpc::models::*`
* mv `fn rpc_server(...)` to `mod rpc`
* replace `pub mod ...` with `pub use crate::rpc::*`