### PR TITLE
Adds result type for rpc and refactors code accordingly

### DIFF
--- a/book/src/rpc/models.rs
+++ b/book/src/rpc/models.rs
@@ -3,7 +3,6 @@ use serde::{Deserialize, Serialize};
 
 use crate::db::models as db_models;
 
-/// Error type returned to API
 pub use helpers::rpc::{Error, RpcResult};
 
 #[derive(Clone, Debug, Deserialize, Serialize)]

--- a/book/src/rpc/models.rs
+++ b/book/src/rpc/models.rs
@@ -4,7 +4,7 @@ use serde::{Deserialize, Serialize};
 use crate::db::models as db_models;
 
 /// Error type returned to API
-pub use helpers::rpc::Error;
+pub use helpers::rpc::{Error, RpcResult};
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Book {

--- a/book/src/rpc/server.rs
+++ b/book/src/rpc/server.rs
@@ -6,12 +6,14 @@ use super::models::{Book, Error};
 use super::service::BookService;
 use crate::db::queries;
 
+pub use helpers::rpc::RpcResult;
+
 #[derive(Clone)]
 pub struct BookServer(pub SocketAddr);
 
 #[tarpc::server]
 impl BookService for BookServer {
-    async fn get_book(self, _: context::Context, book_id: u32) -> Result<Book, Error> {
+    async fn get_book(self, _: context::Context, book_id: u32) -> RpcResult<Book> {
         match queries::get_book_by_id(book_id as i32) {
             Ok(book) => Ok(book),
             Err(e) => {

--- a/book/src/rpc/server.rs
+++ b/book/src/rpc/server.rs
@@ -2,11 +2,9 @@ use diesel::result::Error as DBError;
 use std::net::SocketAddr;
 use tarpc::context;
 
-use super::models::{Book, Error};
+use super::models::{Book, Error, RpcResult};
 use super::service::BookService;
 use crate::db::queries;
-
-pub use helpers::rpc::RpcResult;
 
 #[derive(Clone)]
 pub struct BookServer(pub SocketAddr);

--- a/book/src/rpc/service.rs
+++ b/book/src/rpc/service.rs
@@ -1,6 +1,8 @@
-use super::models::{Book, Error};
+use super::models::Book;
+
+pub use helpers::rpc::RpcResult;
 
 #[tarpc::service]
 pub trait BookService {
-    async fn get_book(book_id: u32) -> Result<Book, Error>;
+    async fn get_book(book_id: u32) -> RpcResult<Book>;
 }

--- a/book/src/rpc/service.rs
+++ b/book/src/rpc/service.rs
@@ -1,6 +1,4 @@
-use super::models::Book;
-
-pub use helpers::rpc::RpcResult;
+use super::models::{Book, RpcResult};
 
 #[tarpc::service]
 pub trait BookService {

--- a/helpers/src/rpc.rs
+++ b/helpers/src/rpc.rs
@@ -9,3 +9,5 @@ pub enum Error {
     InvalidInput,
     NotFound,
 }
+
+pub type RpcResult<T> = Result<T, Error>;

--- a/identity/src/rpc/server.rs
+++ b/identity/src/rpc/server.rs
@@ -14,7 +14,7 @@ pub struct IdentityServer(pub SocketAddr);
 #[tarpc::server]
 impl IdentityService for IdentityServer {
     /// Returns an user
-    async fn get_user(self, _: context::Context, user_id: u32) -> Result<User, Error> {
+    async fn get_user(self, _: context::Context, user_id: u32) -> RpcResult<User> {
         use crate::db::schema::users::dsl;
 
         let result = dsl::users
@@ -43,7 +43,7 @@ impl IdentityService for IdentityServer {
         offset: u32,
         limit: u32,
         user_active: Option<bool>,
-    ) -> Result<Vec<User>, Error> {
+    ) -> RpcResult<Vec<User>> {
         use crate::db::schema::users::dsl;
 
         let results = match user_active {
@@ -77,7 +77,7 @@ impl IdentityService for IdentityServer {
     }
 
     /// Returns a role
-    async fn get_role(self, _: context::Context, role_id: u32) -> Result<Role, Error> {
+    async fn get_role(self, _: context::Context, role_id: u32) -> RpcResult<Role> {
         use crate::db::schema::roles::dsl;
 
         let result = dsl::roles
@@ -97,7 +97,7 @@ impl IdentityService for IdentityServer {
     }
 
     /// Switches the status of an user account between enabled and disabled
-    async fn update_user(self, _: context::Context, user_update: User) -> Result<User, Error> {
+    async fn update_user(self, _: context::Context, user_update: User) -> RpcResult<User> {
         use crate::db::schema::users::dsl;
 
         let result = diesel::update(dsl::users.find(user_update.id as i32))
@@ -125,7 +125,7 @@ impl IdentityService for IdentityServer {
         _: context::Context,
         offset: u32,
         limit: u32,
-    ) -> Result<Vec<Role>, Error> {
+    ) -> RpcResult<Vec<Role>> {
         use crate::db::schema::roles::dsl;
 
         let results = dsl::roles
@@ -149,11 +149,7 @@ impl IdentityService for IdentityServer {
     }
 
     /// Returns an user role
-    async fn get_user_role(
-        self,
-        _: context::Context,
-        user_role_id: u32,
-    ) -> Result<UserRole, Error> {
+    async fn get_user_role(self, _: context::Context, user_role_id: u32) -> RpcResult<UserRole> {
         use crate::db::schema::users_roles::dsl;
 
         let result = dsl::users_roles
@@ -178,7 +174,7 @@ impl IdentityService for IdentityServer {
         offset: u32,
         limit: u32,
         role_id: Option<u32>,
-    ) -> Result<Vec<UserRole>, Error> {
+    ) -> RpcResult<Vec<UserRole>> {
         use crate::db::schema::users_roles::dsl;
 
         let results = match role_id {
@@ -212,7 +208,7 @@ impl IdentityService for IdentityServer {
         self,
         _: context::Context,
         user_role_update: UserRole,
-    ) -> Result<UserRole, Error> {
+    ) -> RpcResult<UserRole> {
         use crate::db::schema::users_roles::dsl;
 
         let result = diesel::update(dsl::users_roles.find(user_role_update.id as i32))
@@ -234,7 +230,7 @@ impl IdentityService for IdentityServer {
     async fn oauth_client_identifier(
         self,
         _: context::Context,
-    ) -> Result<OauthClientIdentifier, Error> {
+    ) -> RpcResult<OauthClientIdentifier> {
         Ok(OauthClientIdentifier {
             identifier: CONFIGURATION.get().unwrap().oauth_client_identifier.clone(),
         })
@@ -245,7 +241,7 @@ impl IdentityService for IdentityServer {
         self,
         _: context::Context,
         code: AuthorizationCode,
-    ) -> Result<SessionToken, Error> {
+    ) -> RpcResult<SessionToken> {
         use crate::db::schema::users::dsl::*;
 
         let authorization_code = match oauth::AuthorizationCode::new(code) {
@@ -365,7 +361,7 @@ impl IdentityService for IdentityServer {
     }
 
     /// Returns the validity and content of a session token
-    async fn session_info(self, _: context::Context, token: String) -> Result<SessionInfo, Error> {
+    async fn session_info(self, _: context::Context, token: String) -> RpcResult<SessionInfo> {
         match Jwt::decode(&CONFIGURATION.get().unwrap().jwt_secret(), &token) {
             Ok(val) => Ok(SessionInfo {
                 sub: val.sub,

--- a/identity/src/rpc/service.rs
+++ b/identity/src/rpc/service.rs
@@ -1,28 +1,25 @@
 use serde::{Deserialize, Serialize};
 
-pub use helpers::rpc::Error;
+pub use helpers::rpc::{Error, RpcResult};
 
 #[tarpc::service]
 pub trait IdentityService {
-    async fn get_user(user_id: u32) -> Result<User, Error>;
-    async fn list_users(
-        offset: u32,
-        limit: u32,
-        user_active: Option<bool>,
-    ) -> Result<Vec<User>, Error>;
-    async fn update_user(user_update: User) -> Result<User, Error>;
-    async fn get_role(role_id: u32) -> Result<Role, Error>;
-    async fn list_roles(offset: u32, limit: u32) -> Result<Vec<Role>, Error>;
-    async fn get_user_role(user_role_id: u32) -> Result<UserRole, Error>;
+    async fn get_user(user_id: u32) -> RpcResult<User>;
+    async fn list_users(offset: u32, limit: u32, user_active: Option<bool>)
+        -> RpcResult<Vec<User>>;
+    async fn update_user(user_update: User) -> RpcResult<User>;
+    async fn get_role(role_id: u32) -> RpcResult<Role>;
+    async fn list_roles(offset: u32, limit: u32) -> RpcResult<Vec<Role>>;
+    async fn get_user_role(user_role_id: u32) -> RpcResult<UserRole>;
     async fn list_user_roles(
         offset: u32,
         limit: u32,
         role_id: Option<u32>,
-    ) -> Result<Vec<UserRole>, Error>;
-    async fn update_user_role(user_role_update: UserRole) -> Result<UserRole, Error>;
-    async fn oauth_client_identifier() -> Result<OauthClientIdentifier, Error>;
-    async fn oauth_authentication(code: AuthorizationCode) -> Result<SessionToken, Error>;
-    async fn session_info(token: String) -> Result<SessionInfo, Error>;
+    ) -> RpcResult<Vec<UserRole>>;
+    async fn update_user_role(user_role_update: UserRole) -> RpcResult<UserRole>;
+    async fn oauth_client_identifier() -> RpcResult<OauthClientIdentifier>;
+    async fn oauth_authentication(code: AuthorizationCode) -> RpcResult<SessionToken>;
+    async fn session_info(token: String) -> RpcResult<SessionInfo>;
 }
 
 #[derive(Debug, Deserialize, Serialize)]


### PR DESCRIPTION
This PR adds the type `RpcResult`, to the `helpers` crate. Usage of this type makes rpc method return types a bit simpler, as we always return `Result<T, Error>`, while Error is `helpers::rpc::Error`.