### PR TITLE
Adds database pagination module to helpers crate

### DIFF
--- a/helpers/src/db/mod.rs
+++ b/helpers/src/db/mod.rs
@@ -1,3 +1,5 @@
+pub mod pagination;
+
 use diesel::prelude::*;
 use diesel::r2d2::{ConnectionManager, Pool, PooledConnection};
 use diesel_migrations::RunMigrationsError;

--- a/helpers/src/db/pagination.rs
+++ b/helpers/src/db/pagination.rs
@@ -7,20 +7,50 @@ use diesel::QueryId;
 
 const DEFAULT_PER_PAGE: i64 = 10;
 
-/**
-This module provides pagination for database queries.
-
-```
-<schema-module>::table
-    .into_boxed()
-    .paginate(<page>)
-    .per_page(<records-per-page>)
-    .load_and_count_pages(<database-connection>)
-```
-This returns a tuple `(Vec<T>, i64)` with the records of the requested page as the first and the amount of pages in the second element.
-**/
-
+/// Provides pagination for database queries.
 pub trait Paginate: Sized + Query {
+    /// Returns a tuple `(Vec<T>, i64)` with the records of the requested page as the first and the amount of pages in the second element.
+    ///
+    /// # Examples
+    /// ```
+    /// # #[macro_use] extern crate diesel;
+    /// # use diesel::prelude::*;
+    /// #
+    /// # mod schema {
+    /// #     table! {
+    /// #         a (id) {
+    /// #             id -> Int4,
+    /// #         }
+    /// #     }
+    /// # }
+    /// #
+    /// # mod models {
+    /// #     #[derive(Queryable)]
+    /// #     pub struct A {
+    /// #         id: i32
+    /// #     }
+    /// # }
+    /// #
+    /// # let tmp_conn = PgConnection::establish("postgres://postgres:password@localhost").unwrap();
+    /// # diesel::sql_query("CREATE DATABASE helpers_db_pagination_doc_comment;").execute(&tmp_conn);
+    /// # let conn = PgConnection::establish("postgres://postgres:password@localhost/helpers_db_pagination_doc_comment").unwrap();
+    /// # diesel::sql_query("CREATE TABLE A(id SERIAL PRIMARY KEY);").execute(&conn);
+    /// #
+    /// use helpers::db::pagination::Paginate;
+    /// use models::A;
+    /// use schema::a;
+    ///
+    /// // items: Vec<A>, num_pages: i64
+    /// let (items, num_pages) = a::table
+    ///     .into_boxed()
+    ///     .paginate(1)  // page number
+    ///     .per_page(10) // items per page (optional, default: 10)
+    ///     .load_and_count_pages::<A>(&conn)
+    ///     .unwrap();
+    ///
+    /// # std::mem::drop(conn);
+    /// # diesel::sql_query("DROP DATABASE helpers_db_pagination_doc_comment;").execute(&tmp_conn);
+    /// ```
     fn paginate(self, page: i64) -> Paginated<Self>;
 }
 

--- a/helpers/src/db/pagination.rs
+++ b/helpers/src/db/pagination.rs
@@ -1,0 +1,69 @@
+use diesel::pg::Pg;
+use diesel::prelude::*;
+use diesel::query_builder::*;
+use diesel::query_dsl::methods::LoadQuery;
+use diesel::sql_types::BigInt;
+use diesel::QueryId;
+
+const DEFAULT_PER_PAGE: i64 = 10;
+
+pub trait Paginate: Sized {
+    fn paginate(self, page: i64) -> Paginated<Self>;
+}
+
+impl<T> Paginate for T {
+    fn paginate(self, page: i64) -> Paginated<Self> {
+        Paginated {
+            query: self,
+            per_page: DEFAULT_PER_PAGE,
+            page,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, QueryId)]
+pub struct Paginated<T> {
+    query: T,
+    page: i64,
+    per_page: i64,
+}
+
+impl<T> Paginated<T> {
+    pub fn per_page(self, per_page: i64) -> Self {
+        Paginated { per_page, ..self }
+    }
+
+    pub fn load_and_count_pages<U>(self, conn: &PgConnection) -> QueryResult<(Vec<U>, i64)>
+    where
+        Self: LoadQuery<PgConnection, (U, i64)>,
+    {
+        let per_page = self.per_page;
+        let results = self.load::<(U, i64)>(conn)?;
+        let total = results.get(0).map(|x| x.1).unwrap_or(0);
+        let records = results.into_iter().map(|x| x.0).collect();
+        let total_pages = (total as f64 / per_page as f64).ceil() as i64;
+        Ok((records, total_pages))
+    }
+}
+
+impl<T: Query> Query for Paginated<T> {
+    type SqlType = (T::SqlType, BigInt);
+}
+
+impl<T> RunQueryDsl<PgConnection> for Paginated<T> {}
+
+impl<T> QueryFragment<Pg> for Paginated<T>
+where
+    T: QueryFragment<Pg>,
+{
+    fn walk_ast(&self, mut out: AstPass<Pg>) -> QueryResult<()> {
+        out.push_sql("SELECT *, COUNT(*) OVER () FROM (");
+        self.query.walk_ast(out.reborrow())?;
+        out.push_sql(") t LIMIT ");
+        out.push_bind_param::<BigInt, _>(&self.per_page)?;
+        out.push_sql(" OFFSET ");
+        let offset = (self.page - 1) * self.per_page;
+        out.push_bind_param::<BigInt, _>(&offset)?;
+        Ok(())
+    }
+}

--- a/helpers/src/db/pagination.rs
+++ b/helpers/src/db/pagination.rs
@@ -20,11 +20,11 @@ This module provides pagination for database queries.
 This returns a tuple `(Vec<T>, i64)` with the records of the requested page as the first and the amount of pages in the second element.
 **/
 
-pub trait Paginate: Sized {
+pub trait Paginate: Sized + Query {
     fn paginate(self, page: i64) -> Paginated<Self>;
 }
 
-impl<T> Paginate for T {
+impl<T: Query> Paginate for T {
     fn paginate(self, page: i64) -> Paginated<Self> {
         Paginated {
             query: self,

--- a/helpers/src/rpc.rs
+++ b/helpers/src/rpc.rs
@@ -16,7 +16,7 @@ impl From<DBError> for Error {
         log::debug!("{}", e);
         match e {
             DBError::NotFound => Error::NotFound,
-            DBError::QueryBuilderError(_) => Error::InvalidInput,
+            DBError::QueryBuilderError(_) => Error::InvalidData,
             _ => Error::InternalError,
         }
     }

--- a/helpers/src/rpc.rs
+++ b/helpers/src/rpc.rs
@@ -16,6 +16,7 @@ impl From<DBError> for Error {
         log::debug!("{}", e);
         match e {
             DBError::NotFound => Error::NotFound,
+            DBError::QueryBuilderError(_) => Error::InvalidData,
             _ => Error::InternalError,
         }
     }

--- a/helpers/src/rpc.rs
+++ b/helpers/src/rpc.rs
@@ -16,7 +16,7 @@ impl From<DBError> for Error {
         log::debug!("{}", e);
         match e {
             DBError::NotFound => Error::NotFound,
-            DBError::QueryBuilderError(_) => Error::InvalidData,
+            DBError::QueryBuilderError(_) => Error::InvalidInput,
             _ => Error::InternalError,
         }
     }


### PR DESCRIPTION
This adds a database pagination module to the helpers crate. The pagination feature can split the results in pages and return the number of pages.

```
<table>
    .filter(<some-filter>)
    .paginate(<page>)
    .per_page(<results-per-page>)
    .load_and_count_pages(<db-connection>)
```
Returns a `<Vec<T>, i64>`, where T is the model type.