### PR TITLE
`book`: make series optional

### DIFF
--- a/book/src/db/queries.rs
+++ b/book/src/db/queries.rs
@@ -36,12 +36,13 @@ fn get_book_authors(book_id: i32) -> QueryResult<Vec<db_models::Person>> {
         .get_results::<db_models::Person>(&get_conn())
 }
 
-fn get_book_series(book_id: i32) -> QueryResult<db_models::Series> {
+fn get_book_series(book_id: i32) -> QueryResult<Option<db_models::Series>> {
     books_series::table
         .filter(books_series::book_id.eq(book_id))
         .inner_join(series::table)
         .select(series::all_columns)
         .get_result::<db_models::Series>(&get_conn())
+        .optional()
 }
 
 fn get_book_subject_areas(book_id: i32) -> QueryResult<Vec<db_models::SubjectArea>> {

--- a/book/src/rpc/models.rs
+++ b/book/src/rpc/models.rs
@@ -22,7 +22,7 @@ pub struct Book {
     pub category: db_models::Category,
     pub language: db_models::Language,
     pub publisher: db_models::Publisher,
-    pub series: db_models::Series,
+    pub series: Option<db_models::Series>,
 
     // many-to-many
     pub authors: Vec<db_models::Person>,
@@ -35,7 +35,7 @@ impl Book {
         category: db_models::Category,
         language: db_models::Language,
         publisher: db_models::Publisher,
-        series: db_models::Series,
+        series: Option<db_models::Series>,
         authors: Vec<db_models::Person>,
         subject_areas: Vec<db_models::SubjectArea>,
     ) -> Self {


### PR DESCRIPTION
While doing #136 I overlooked that a book might not have a series and the field in the return-type should thereby be optional. This PR fixes this.