### PR TITLE
`helpers::rpc`: `impl From<diesel::result::Error> for Error`

### DIFF
--- a/book/src/rpc/server.rs
+++ b/book/src/rpc/server.rs
@@ -11,6 +11,18 @@ pub struct BookServer(pub SocketAddr);
 #[tarpc::server]
 impl BookService for BookServer {
     async fn get_book(self, _: context::Context, book_id: u32) -> RpcResult<Book> {
-        Ok(queries::get_book_by_id(book_id as i32)?)
+        let book_id = book_id as i32;
+
+        let (raw_book, category, language, publisher) = queries::get_book_by_id(book_id)?;
+
+        Ok(Book::new(
+            raw_book,
+            category,
+            language,
+            publisher,
+            queries::get_book_series(book_id)?,
+            queries::get_book_authors(book_id)?,
+            queries::get_book_subject_areas(book_id)?,
+        ))
     }
 }

--- a/book/src/rpc/server.rs
+++ b/book/src/rpc/server.rs
@@ -1,8 +1,7 @@
-use diesel::result::Error as DBError;
 use std::net::SocketAddr;
 use tarpc::context;
 
-use super::models::{Book, Error, RpcResult};
+use super::models::{Book, RpcResult};
 use super::service::BookService;
 use crate::db::queries;
 
@@ -12,15 +11,6 @@ pub struct BookServer(pub SocketAddr);
 #[tarpc::server]
 impl BookService for BookServer {
     async fn get_book(self, _: context::Context, book_id: u32) -> RpcResult<Book> {
-        match queries::get_book_by_id(book_id as i32) {
-            Ok(book) => Ok(book),
-            Err(e) => {
-                log::debug!("Error (BookServer::get_book): {}", e);
-                match e {
-                    DBError::NotFound => Err(Error::NotFound),
-                    _ => Err(Error::InternalError),
-                }
-            }
-        }
+        Ok(queries::get_book_by_id(book_id as i32)?)
     }
 }

--- a/helpers/src/rpc.rs
+++ b/helpers/src/rpc.rs
@@ -1,3 +1,4 @@
+use diesel::result::Error as DBError;
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
@@ -8,6 +9,16 @@ pub enum Error {
     InvalidData,
     InvalidInput,
     NotFound,
+}
+
+impl From<DBError> for Error {
+    fn from(e: DBError) -> Self {
+        log::debug!("{}", e);
+        match e {
+            DBError::NotFound => Error::NotFound,
+            _ => Error::InternalError,
+        }
+    }
 }
 
 pub type RpcResult<T> = Result<T, Error>;


### PR DESCRIPTION
This PR implements an adapter from `diesel::result::Error` to our custom error type. This is useful because we now don't need to match it manually in 98% of the cases, but only when we don't want the default behaviour.

The PR includes a 2nd commit showcasing this. Additionally it can be used in `identity/src/rpc/server.rs`.