### PR TITLE
CD: Unify jobs

### DIFF
--- a/.github/workflows/cd-dev-api.yml
+++ b/.github/workflows/cd-dev-api.yml
@@ -8,7 +8,7 @@ on:
             - "**/cd-dev-api.yml"
 
 jobs:
-    deploy:
+    build_deploy:
         runs-on: ubuntu-latest
 
         env:

--- a/.github/workflows/cd-dev-api.yml
+++ b/.github/workflows/cd-dev-api.yml
@@ -1,34 +1,24 @@
 on:
     push:
         branches:
-            - 'master'
+            - "master"
         paths:
-            - 'api/**'
-            - 'Cargo.lock'
-            - '**/cd-dev-api.yml'
+            - "api/**"
+            - "Cargo.lock"
+            - "**/cd-dev-api.yml"
 
 jobs:
-    build:
+    deploy:
         runs-on: ubuntu-latest
+
+        env:
+            SERVICE_NAME: api
+            REPOSITORY: ${{ secrets.AWS_ECR_REGISTRY }}
+            IMAGE_TAG: latest-dev
+
         steps:
             - uses: actions/checkout@v2
-            - name: 'Build and save Docker image'
-              env:
-                  REGISTRY: ${{ secrets.AWS_ECR_REGISTRY }}
-                  REPOSITORY: code-library-api
-                  IMAGE_TAG: ${{ github.sha }}
-              run: |
-                  docker build -t "$REGISTRY/$REPOSITORY:$IMAGE_TAG" -f api/Dockerfile .
-                  docker image save -o image "$REGISTRY/$REPOSITORY:$IMAGE_TAG"
-            - name: 'Upload the Docker image'
-              uses: actions/upload-artifact@v2
-              with:
-                  name: image
-                  path: image
-    deploy:
-        needs: build
-        runs-on: ubuntu-latest
-        steps:
+
             - name: Configure AWS credentials
               uses: aws-actions/configure-aws-credentials@v1
               with:
@@ -38,20 +28,8 @@ jobs:
             - name: Login to Amazon ECR
               id: login-ecr
               uses: aws-actions/amazon-ecr-login@v1
-            - name: 'Download the Docker image'
-              uses: actions/download-artifact@v2
-              with:
-                  name: image
-            - name: 'Load Docker image'
-              run: docker load -i image
-            - name: 'Tag Docker image as latest'
-              env:
-                  REGISTRY: ${{ secrets.AWS_ECR_REGISTRY }}
-                  REPOSITORY: code-library-api
-                  IMAGE_TAG: ${{ github.sha }}
-              run: docker tag "$REGISTRY/$REPOSITORY:$IMAGE_TAG" "$REGISTRY/$REPOSITORY:latest-dev"
-            - name: 'Push Docker image'
-              env:
-                  REGISTRY: ${{ secrets.AWS_ECR_REGISTRY }}
-                  REPOSITORY: code-library-api
-              run: docker push "$REGISTRY/$REPOSITORY:latest-dev"
+
+            - name: Build Docker image
+              run: docker build -t $REPOSITORY/code-library-$SERVICE_NAME:$IMAGE_TAG -f $SERVICE_NAME/Dockerfile .
+            - name: Push Docker image
+              run: docker push $REPOSITORY/code-library-$SERVICE_NAME:$IMAGE_TAG

--- a/.github/workflows/cd-dev-book.yml
+++ b/.github/workflows/cd-dev-book.yml
@@ -8,7 +8,7 @@ on:
             - "**/cd-dev-book.yml"
 
 jobs:
-    deploy:
+    build_deploy:
         runs-on: ubuntu-latest
 
         env:

--- a/.github/workflows/cd-dev-book.yml
+++ b/.github/workflows/cd-dev-book.yml
@@ -1,34 +1,24 @@
 on:
     push:
         branches:
-            - 'master'
+            - "master"
         paths:
-            - 'book/**'
-            - 'Cargo.lock'
-            - '**/cd-dev-book.yml'
+            - "book/**"
+            - "Cargo.lock"
+            - "**/cd-dev-book.yml"
 
 jobs:
-    build:
+    deploy:
         runs-on: ubuntu-latest
+
+        env:
+            SERVICE_NAME: book
+            REPOSITORY: ${{ secrets.AWS_ECR_REGISTRY }}
+            IMAGE_TAG: latest-dev
+
         steps:
             - uses: actions/checkout@v2
-            - name: 'Build and save Docker image'
-              env:
-                  REGISTRY: ${{ secrets.AWS_ECR_REGISTRY }}
-                  REPOSITORY: code-library-book
-                  IMAGE_TAG: ${{ github.sha }}
-              run: |
-                  docker build -t "$REGISTRY/$REPOSITORY:$IMAGE_TAG" -f book/Dockerfile .
-                  docker image save -o image "$REGISTRY/$REPOSITORY:$IMAGE_TAG"
-            - name: 'Upload the Docker image'
-              uses: actions/upload-artifact@v2
-              with:
-                  name: image
-                  path: image
-    deploy:
-        needs: build
-        runs-on: ubuntu-latest
-        steps:
+
             - name: Configure AWS credentials
               uses: aws-actions/configure-aws-credentials@v1
               with:
@@ -38,20 +28,8 @@ jobs:
             - name: Login to Amazon ECR
               id: login-ecr
               uses: aws-actions/amazon-ecr-login@v1
-            - name: 'Download the Docker image'
-              uses: actions/download-artifact@v2
-              with:
-                  name: image
-            - name: 'Load Docker image'
-              run: docker load -i image
-            - name: 'Tag Docker image as latest'
-              env:
-                  REGISTRY: ${{ secrets.AWS_ECR_REGISTRY }}
-                  REPOSITORY: code-library-book
-                  IMAGE_TAG: ${{ github.sha }}
-              run: docker tag "$REGISTRY/$REPOSITORY:$IMAGE_TAG" "$REGISTRY/$REPOSITORY:latest-dev"
-            - name: 'Push Docker image'
-              env:
-                  REGISTRY: ${{ secrets.AWS_ECR_REGISTRY }}
-                  REPOSITORY: code-library-book
-              run: docker push "$REGISTRY/$REPOSITORY:latest-dev"
+
+            - name: Build Docker image
+              run: docker build -t $REPOSITORY/code-library-$SERVICE_NAME:$IMAGE_TAG -f $SERVICE_NAME/Dockerfile .
+            - name: Push Docker image
+              run: docker push $REPOSITORY/code-library-$SERVICE_NAME:$IMAGE_TAG

--- a/.github/workflows/cd-dev-borrow.yml
+++ b/.github/workflows/cd-dev-borrow.yml
@@ -8,7 +8,7 @@ on:
             - "**/cd-dev-borrow.yml"
 
 jobs:
-    deploy:
+    build_deploy:
         runs-on: ubuntu-latest
 
         env:

--- a/.github/workflows/cd-dev-borrow.yml
+++ b/.github/workflows/cd-dev-borrow.yml
@@ -1,34 +1,24 @@
 on:
     push:
         branches:
-            - 'master'
+            - "master"
         paths:
-            - 'borrow/**'
-            - 'Cargo.lock'
-            - '**/cd-dev-borrow.yml'
+            - "borrow/**"
+            - "Cargo.lock"
+            - "**/cd-dev-borrow.yml"
 
 jobs:
-    build:
+    deploy:
         runs-on: ubuntu-latest
+
+        env:
+            SERVICE_NAME: borrow
+            REPOSITORY: ${{ secrets.AWS_ECR_REGISTRY }}
+            IMAGE_TAG: latest-dev
+
         steps:
             - uses: actions/checkout@v2
-            - name: 'Build and save Docker image'
-              env:
-                  REGISTRY: ${{ secrets.AWS_ECR_REGISTRY }}
-                  REPOSITORY: code-library-borrow
-                  IMAGE_TAG: ${{ github.sha }}
-              run: |
-                  docker build -t "$REGISTRY/$REPOSITORY:$IMAGE_TAG" -f borrow/Dockerfile .
-                  docker image save -o image "$REGISTRY/$REPOSITORY:$IMAGE_TAG"
-            - name: 'Upload the Docker image'
-              uses: actions/upload-artifact@v2
-              with:
-                  name: image
-                  path: image
-    deploy:
-        needs: build
-        runs-on: ubuntu-latest
-        steps:
+
             - name: Configure AWS credentials
               uses: aws-actions/configure-aws-credentials@v1
               with:
@@ -38,20 +28,8 @@ jobs:
             - name: Login to Amazon ECR
               id: login-ecr
               uses: aws-actions/amazon-ecr-login@v1
-            - name: 'Download the Docker image'
-              uses: actions/download-artifact@v2
-              with:
-                  name: image
-            - name: 'Load Docker image'
-              run: docker load -i image
-            - name: 'Tag Docker image as latest'
-              env:
-                  REGISTRY: ${{ secrets.AWS_ECR_REGISTRY }}
-                  REPOSITORY: code-library-borrow
-                  IMAGE_TAG: ${{ github.sha }}
-              run: docker tag "$REGISTRY/$REPOSITORY:$IMAGE_TAG" "$REGISTRY/$REPOSITORY:latest-dev"
-            - name: 'Push Docker image'
-              env:
-                  REGISTRY: ${{ secrets.AWS_ECR_REGISTRY }}
-                  REPOSITORY: code-library-borrow
-              run: docker push "$REGISTRY/$REPOSITORY:latest-dev"
+
+            - name: Build Docker image
+              run: docker build -t $REPOSITORY/code-library-$SERVICE_NAME:$IMAGE_TAG -f $SERVICE_NAME/Dockerfile .
+            - name: Push Docker image
+              run: docker push $REPOSITORY/code-library-$SERVICE_NAME:$IMAGE_TAG

--- a/.github/workflows/cd-dev-identity.yml
+++ b/.github/workflows/cd-dev-identity.yml
@@ -8,7 +8,7 @@ on:
             - "**/cd-dev-identity.yml"
 
 jobs:
-    deploy:
+    build_deploy:
         runs-on: ubuntu-latest
 
         env:

--- a/.github/workflows/cd-dev-identity.yml
+++ b/.github/workflows/cd-dev-identity.yml
@@ -1,34 +1,24 @@
 on:
     push:
         branches:
-            - 'master'
+            - "master"
         paths:
-            - 'identity/**'
-            - 'Cargo.lock'
-            - '**/cd-dev-identity.yml'
+            - "identity/**"
+            - "Cargo.lock"
+            - "**/cd-dev-identity.yml"
 
 jobs:
-    build:
+    deploy:
         runs-on: ubuntu-latest
+
+        env:
+            SERVICE_NAME: identity
+            REPOSITORY: ${{ secrets.AWS_ECR_REGISTRY }}
+            IMAGE_TAG: latest-dev
+
         steps:
             - uses: actions/checkout@v2
-            - name: 'Build and save Docker image'
-              env:
-                  REGISTRY: ${{ secrets.AWS_ECR_REGISTRY }}
-                  REPOSITORY: code-library-identity
-                  IMAGE_TAG: ${{ github.sha }}
-              run: |
-                  docker build -t "$REGISTRY/$REPOSITORY:$IMAGE_TAG" -f identity/Dockerfile .
-                  docker image save -o image "$REGISTRY/$REPOSITORY:$IMAGE_TAG"
-            - name: 'Upload the Docker image'
-              uses: actions/upload-artifact@v2
-              with:
-                  name: image
-                  path: image
-    deploy:
-        needs: build
-        runs-on: ubuntu-latest
-        steps:
+
             - name: Configure AWS credentials
               uses: aws-actions/configure-aws-credentials@v1
               with:
@@ -38,20 +28,8 @@ jobs:
             - name: Login to Amazon ECR
               id: login-ecr
               uses: aws-actions/amazon-ecr-login@v1
-            - name: 'Download the Docker image'
-              uses: actions/download-artifact@v2
-              with:
-                  name: image
-            - name: 'Load Docker image'
-              run: docker load -i image
-            - name: 'Tag Docker image as latest'
-              env:
-                  REGISTRY: ${{ secrets.AWS_ECR_REGISTRY }}
-                  REPOSITORY: code-library-identity
-                  IMAGE_TAG: ${{ github.sha }}
-              run: docker tag "$REGISTRY/$REPOSITORY:$IMAGE_TAG" "$REGISTRY/$REPOSITORY:latest-dev"
-            - name: 'Push Docker image'
-              env:
-                  REGISTRY: ${{ secrets.AWS_ECR_REGISTRY }}
-                  REPOSITORY: code-library-identity
-              run: docker push "$REGISTRY/$REPOSITORY:latest-dev"
+
+            - name: Build Docker image
+              run: docker build -t $REPOSITORY/code-library-$SERVICE_NAME:$IMAGE_TAG -f $SERVICE_NAME/Dockerfile .
+            - name: Push Docker image
+              run: docker push $REPOSITORY/code-library-$SERVICE_NAME:$IMAGE_TAG

--- a/.github/workflows/cd-dev-notification.yml
+++ b/.github/workflows/cd-dev-notification.yml
@@ -8,7 +8,7 @@ on:
             - "**/cd-dev-notification.yml"
 
 jobs:
-    deploy:
+    build_deploy:
         runs-on: ubuntu-latest
 
         env:

--- a/.github/workflows/cd-dev-notification.yml
+++ b/.github/workflows/cd-dev-notification.yml
@@ -1,34 +1,24 @@
 on:
     push:
         branches:
-            - 'master'
+            - "master"
         paths:
-            - 'notification/**'
-            - 'Cargo.lock'
-            - '**/cd-dev-notification.yml'
+            - "notification/**"
+            - "Cargo.lock"
+            - "**/cd-dev-notification.yml"
 
 jobs:
-    build:
+    deploy:
         runs-on: ubuntu-latest
+
+        env:
+            SERVICE_NAME: notification
+            REPOSITORY: ${{ secrets.AWS_ECR_REGISTRY }}
+            IMAGE_TAG: latest-dev
+
         steps:
             - uses: actions/checkout@v2
-            - name: 'Build and save Docker image'
-              env:
-                  REGISTRY: ${{ secrets.AWS_ECR_REGISTRY }}
-                  REPOSITORY: code-library-notification
-                  IMAGE_TAG: ${{ github.sha }}
-              run: |
-                  docker build -t "$REGISTRY/$REPOSITORY:$IMAGE_TAG" -f notification/Dockerfile .
-                  docker image save -o image "$REGISTRY/$REPOSITORY:$IMAGE_TAG"
-            - name: 'Upload the Docker image'
-              uses: actions/upload-artifact@v2
-              with:
-                  name: image
-                  path: image
-    deploy:
-        needs: build
-        runs-on: ubuntu-latest
-        steps:
+
             - name: Configure AWS credentials
               uses: aws-actions/configure-aws-credentials@v1
               with:
@@ -38,20 +28,8 @@ jobs:
             - name: Login to Amazon ECR
               id: login-ecr
               uses: aws-actions/amazon-ecr-login@v1
-            - name: 'Download the Docker image'
-              uses: actions/download-artifact@v2
-              with:
-                  name: image
-            - name: 'Load Docker image'
-              run: docker load -i image
-            - name: 'Tag Docker image as latest'
-              env:
-                  REGISTRY: ${{ secrets.AWS_ECR_REGISTRY }}
-                  REPOSITORY: code-library-notification
-                  IMAGE_TAG: ${{ github.sha }}
-              run: docker tag "$REGISTRY/$REPOSITORY:$IMAGE_TAG" "$REGISTRY/$REPOSITORY:latest-dev"
-            - name: 'Push Docker image'
-              env:
-                  REGISTRY: ${{ secrets.AWS_ECR_REGISTRY }}
-                  REPOSITORY: code-library-notification
-              run: docker push "$REGISTRY/$REPOSITORY:latest-dev"
+
+            - name: Build Docker image
+              run: docker build -t $REPOSITORY/code-library-$SERVICE_NAME:$IMAGE_TAG -f $SERVICE_NAME/Dockerfile .
+            - name: Push Docker image
+              run: docker push $REPOSITORY/code-library-$SERVICE_NAME:$IMAGE_TAG


### PR DESCRIPTION
This PR unifies the currently two jobs of the cd-workflows into one.

Additional simplifications:
* drop up- and downloading of docker image
    _(we can keep the upload if you want, but I'd vote for not to)_
* move `env` specification from individual `step`s to whole `job`
* rm additional tagging step (not needed anymore)