### PR TITLE
Libarify `identity` service

### DIFF
--- a/api/src/endpoints/identity.rs
+++ b/api/src/endpoints/identity.rs
@@ -2,7 +2,7 @@ use std::{collections::HashMap, convert::Infallible};
 use tarpc::context;
 use warp::Reply;
 
-use identity_rpc_service::Error;
+use identity_lib::models::Error;
 
 use crate::response;
 

--- a/api/src/rpc.rs
+++ b/api/src/rpc.rs
@@ -4,7 +4,7 @@ use tarpc::client;
 use tokio_serde::formats::Json;
 
 use book_lib::service::BookServiceClient;
-use identity_rpc_service::IdentityServiceClient;
+use identity_lib::service::IdentityServiceClient;
 
 use crate::CONFIGURATION;
 

--- a/identity/Cargo.toml
+++ b/identity/Cargo.toml
@@ -5,8 +5,8 @@ authors = ["Markus Merklinger <markus.merklinger@code.berlin>"]
 edition = "2018"
 
 [lib]
-name = "identity_rpc_service"
-path = "src/rpc/service.rs"
+name = "identity_lib"
+path = "src/lib.rs"
 
 [dependencies]
 diesel = { version = "1.4", features = ["postgres", "r2d2"] }

--- a/identity/src/lib.rs
+++ b/identity/src/lib.rs
@@ -1,0 +1,18 @@
+use diesel::prelude::*;
+use diesel::r2d2::{ConnectionManager, Pool};
+use once_cell::sync::OnceCell;
+
+#[macro_use]
+extern crate diesel;
+
+mod authentication;
+mod config;
+mod db;
+mod rpc;
+mod session;
+
+pub use crate::config::Configuration;
+pub use crate::rpc::*;
+
+pub static CONFIGURATION: OnceCell<Configuration> = OnceCell::new();
+pub static DB: OnceCell<Pool<ConnectionManager<PgConnection>>> = OnceCell::new();

--- a/identity/src/rpc/mod.rs
+++ b/identity/src/rpc/mod.rs
@@ -1,2 +1,30 @@
+use std::io;
+use std::net::SocketAddr;
+
+use futures::{future, prelude::*};
+use tarpc::server::{BaseChannel, Channel, Handler};
+use tokio_serde::formats::Json;
+
+pub mod models;
 pub mod server;
 pub mod service;
+
+use self::{server::IdentityServer, service::IdentityService};
+
+pub async fn rpc_server(addr: &SocketAddr) -> io::Result<(impl Future<Output = ()>, SocketAddr)> {
+    let incoming = tarpc::serde_transport::tcp::listen(addr, Json::default).await?;
+    let addr = incoming.local_addr();
+
+    let fut = incoming
+        .filter_map(|r| future::ready(r.ok()))
+        .map(BaseChannel::with_defaults)
+        .max_channels_per_key(11, |t| t.as_ref().peer_addr().unwrap().ip())
+        .map(|channel| {
+            let server = IdentityServer(channel.as_ref().as_ref().peer_addr().unwrap());
+            channel.respond_with(server.serve()).execute()
+        })
+        .buffer_unordered(10)
+        .for_each(|_| async {});
+
+    Ok((fut, addr))
+}

--- a/identity/src/rpc/models.rs
+++ b/identity/src/rpc/models.rs
@@ -1,0 +1,53 @@
+use serde::{Deserialize, Serialize};
+
+pub use helpers::rpc::{Error, RpcResult};
+
+pub use crate::db::models;
+
+#[derive(Debug, Deserialize, Serialize)]
+pub struct User {
+    pub id: i32,
+    pub sub: String,
+    pub email: String,
+    pub given_name: String,
+    pub family_name: String,
+    pub picture: String,
+    pub active: bool,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+pub struct Role {
+    pub id: i32,
+    pub name: String,
+    pub access_manage_books: bool,
+    pub access_manage_roles: bool,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+pub struct UserRole {
+    pub id: i32,
+    pub user_id: i32,
+    pub role_id: i32,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+pub struct OauthClientIdentifier {
+    pub identifier: String,
+}
+
+pub type AuthorizationCode = String;
+
+#[derive(Debug, Deserialize, Serialize)]
+pub struct SessionToken {
+    pub token: String,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+pub struct SessionInfo {
+    pub sub: u32,
+    pub given_name: String,
+    pub family_name: String,
+    pub picture: String,
+    pub iat: u64,
+    pub exp: u64,
+}

--- a/identity/src/rpc/server.rs
+++ b/identity/src/rpc/server.rs
@@ -1,12 +1,14 @@
-use super::service::*;
+use diesel::prelude::*;
+use std::net::SocketAddr;
+use std::time::{Duration, SystemTime};
+use tarpc::context;
+
+use super::models::*;
+use super::service::IdentityService;
 use crate::authentication::oauth;
 use crate::db::models;
 use crate::session::jwt::Jwt;
-use crate::CONFIGURATION;
-use crate::DB;
-use diesel::prelude::*;
-use std::{net::SocketAddr, time::Duration, time::SystemTime};
-use tarpc::context;
+use crate::{CONFIGURATION, DB};
 
 #[derive(Clone)]
 pub struct IdentityServer(pub SocketAddr);

--- a/identity/src/rpc/service.rs
+++ b/identity/src/rpc/service.rs
@@ -1,6 +1,4 @@
-use serde::{Deserialize, Serialize};
-
-pub use helpers::rpc::{Error, RpcResult};
+use super::models::*;
 
 #[tarpc::service]
 pub trait IdentityService {
@@ -20,52 +18,4 @@ pub trait IdentityService {
     async fn oauth_client_identifier() -> RpcResult<OauthClientIdentifier>;
     async fn oauth_authentication(code: AuthorizationCode) -> RpcResult<SessionToken>;
     async fn session_info(token: String) -> RpcResult<SessionInfo>;
-}
-
-#[derive(Debug, Deserialize, Serialize)]
-pub struct User {
-    pub id: i32,
-    pub sub: String,
-    pub email: String,
-    pub given_name: String,
-    pub family_name: String,
-    pub picture: String,
-    pub active: bool,
-}
-
-#[derive(Debug, Deserialize, Serialize)]
-pub struct Role {
-    pub id: i32,
-    pub name: String,
-    pub access_manage_books: bool,
-    pub access_manage_roles: bool,
-}
-
-#[derive(Debug, Deserialize, Serialize)]
-pub struct UserRole {
-    pub id: i32,
-    pub user_id: i32,
-    pub role_id: i32,
-}
-
-#[derive(Debug, Deserialize, Serialize)]
-pub struct OauthClientIdentifier {
-    pub identifier: String,
-}
-
-pub type AuthorizationCode = String;
-
-#[derive(Debug, Deserialize, Serialize)]
-pub struct SessionToken {
-    pub token: String,
-}
-
-#[derive(Debug, Deserialize, Serialize)]
-pub struct SessionInfo {
-    pub sub: u32,
-    pub given_name: String,
-    pub family_name: String,
-    pub picture: String,
-    pub iat: u64,
-    pub exp: u64,
 }


### PR DESCRIPTION
* `identity`: Libarify
    * `main.rs`:
    	* extract libary functionality into `lib.rs`
	* extract server startup into `rpc::mod.rs`
    * `Cargo.toml`: adapt libary configuration
    * `rpc::service`: Extract models into `rpc::models`
* `api::{rpc, endpoints::identity}`: Adapt to identity lib restructuring