### PR TITLE
Removes global static configuration and database from identity service

### DIFF
--- a/identity/src/lib/config.rs
+++ b/identity/src/lib/config.rs
@@ -1,11 +1,8 @@
 use std::net::{IpAddr, SocketAddr};
 
 use envconfig::Envconfig;
-use once_cell::sync::OnceCell;
 
-pub static CONFIGURATION: OnceCell<Configuration> = OnceCell::new();
-
-#[derive(Envconfig, Debug)]
+#[derive(Envconfig, Debug, Clone)]
 pub struct Configuration {
     #[envconfig(from = "DB_HOST_IP", default = "127.0.0.1")]
     db_host_ip: IpAddr,

--- a/identity/src/lib/db/mod.rs
+++ b/identity/src/lib/db/mod.rs
@@ -3,6 +3,5 @@ pub mod schema;
 
 use diesel::prelude::*;
 use diesel::r2d2::{ConnectionManager, Pool};
-use once_cell::sync::OnceCell;
 
-pub static DB: OnceCell<Pool<ConnectionManager<PgConnection>>> = OnceCell::new();
+pub type Db = Pool<ConnectionManager<PgConnection>>;


### PR DESCRIPTION
Removes global static configuration and database from identity service. The motivation for this change is to provide better support for testing.