### PR TITLE
Refactor/book db conn

### DIFF
--- a/book/src/config.rs
+++ b/book/src/config.rs
@@ -1,9 +1,6 @@
 use std::net::{IpAddr, SocketAddr};
 
 use envconfig::Envconfig;
-use once_cell::sync::OnceCell;
-
-pub static CONFIGURATION: OnceCell<Configuration> = OnceCell::new();
 
 #[derive(Envconfig, Debug)]
 pub struct Configuration {

--- a/book/src/lib/db/mod.rs
+++ b/book/src/lib/db/mod.rs
@@ -1,16 +1,14 @@
-pub mod models;
-pub mod queries;
-pub mod schema;
+pub(crate) mod models;
+pub(crate) mod queries;
+pub(crate) mod schema;
 
 use diesel::r2d2::{ConnectionManager, Pool, PooledConnection};
 use diesel::PgConnection;
-use once_cell::sync::OnceCell;
 
-pub static DB: OnceCell<Pool<ConnectionManager<PgConnection>>> = OnceCell::new();
+pub type DbPool = Pool<ConnectionManager<PgConnection>>;
+pub type DbConn = PooledConnection<ConnectionManager<PgConnection>>;
 
-pub fn get_conn() -> PooledConnection<ConnectionManager<PgConnection>> {
-    DB.get()
-        .expect("No database connection set")
-        .get()
-        .expect("Failed to get database connection")
+pub fn new_db_pool(database_url: &str) -> DbPool {
+    Pool::new(ConnectionManager::new(database_url))
+        .expect("Failed creating new database connection")
 }

--- a/book/src/lib/lib.rs
+++ b/book/src/lib/lib.rs
@@ -1,8 +1,7 @@
-mod db;
+pub mod db;
 mod rpc;
 
 #[macro_use]
 extern crate diesel;
 
-pub use crate::db::DB;
 pub use crate::rpc::*;

--- a/book/src/lib/rpc/mod.rs
+++ b/book/src/lib/rpc/mod.rs
@@ -4,27 +4,35 @@ pub mod service;
 
 use std::io;
 use std::net::SocketAddr;
+use std::sync::Arc;
 
 use futures::{future, prelude::*};
 use tarpc::server::{BaseChannel, Channel, Handler};
 use tokio_serde::formats::Json;
 
 use self::{server::BookServer, service::BookService};
+use crate::db::DbPool;
 
-pub async fn rpc_server(addr: &SocketAddr) -> io::Result<(impl Future<Output = ()>, SocketAddr)> {
+pub async fn rpc_server(
+    addr: &SocketAddr,
+    db_pool: Arc<DbPool>,
+) -> io::Result<(impl Future<Output = ()>, SocketAddr)> {
     let incoming = tarpc::serde_transport::tcp::listen(addr, Json::default).await?;
     let addr = incoming.local_addr();
 
-    let fut = incoming
+    let server = incoming
         .filter_map(|r| future::ready(r.ok()))
         .map(BaseChannel::with_defaults)
         .max_channels_per_key(1, |t| t.as_ref().peer_addr().unwrap().ip())
-        .map(|channel| {
-            let server = BookServer(channel.as_ref().as_ref().peer_addr().unwrap());
+        .map(move |channel| {
+            let server = BookServer::new(
+                channel.as_ref().as_ref().peer_addr().unwrap(),
+                Arc::clone(&db_pool),
+            );
             channel.respond_with(server.serve()).execute()
         })
         .buffer_unordered(10)
         .for_each(|_| async {});
 
-    Ok((fut, addr))
+    Ok((server, addr))
 }


### PR DESCRIPTION
* `helpers::db`: Let `run_migration` take `PgConnection`
    --> My optimal solution would be to take a generic connection, but couldn't figure out how to do it:
    ```rust
    fn run_migration(
        run_embedded_migration: impl FnOnce(&impl Connection<Backend = Pg>) -> Result<(), RunMigrationsError>,
        db_conn: &impl Connection<Backend = Pg>,
    ) 
    ```
* `book`: Mv `db_conn` into server
