### PR TITLE
Move identity service rpc models into their own module

### DIFF
--- a/identity/src/lib/rpc/mod.rs
+++ b/identity/src/lib/rpc/mod.rs
@@ -1,3 +1,4 @@
+pub mod models;
 pub mod server;
 pub mod service;
 

--- a/identity/src/lib/rpc/models.rs
+++ b/identity/src/lib/rpc/models.rs
@@ -1,0 +1,49 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+pub struct User {
+    pub id: i32,
+    pub sub: String,
+    pub email: String,
+    pub given_name: String,
+    pub family_name: String,
+    pub picture: String,
+    pub active: bool,
+}
+
+#[derive(Debug, Deserialize, PartialEq, Serialize)]
+pub struct Role {
+    pub id: i32,
+    pub name: String,
+    pub access_manage_books: bool,
+    pub access_manage_roles: bool,
+}
+
+#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+pub struct UserRole {
+    pub id: i32,
+    pub user_id: i32,
+    pub role_id: i32,
+}
+
+#[derive(Debug, Deserialize, PartialEq, Serialize)]
+pub struct OauthClientIdentifier {
+    pub identifier: String,
+}
+
+pub type AuthorizationCode = String;
+
+#[derive(Debug, Deserialize, PartialEq, Serialize)]
+pub struct SessionToken {
+    pub token: String,
+}
+
+#[derive(Debug, Deserialize, PartialEq, Serialize)]
+pub struct SessionInfo {
+    pub sub: u32,
+    pub given_name: String,
+    pub family_name: String,
+    pub picture: String,
+    pub iat: u64,
+    pub exp: u64,
+}

--- a/identity/src/lib/rpc/models.rs
+++ b/identity/src/lib/rpc/models.rs
@@ -1,5 +1,7 @@
 use serde::{Deserialize, Serialize};
 
+pub type AuthorizationCode = String;
+
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
 pub struct User {
     pub id: i32,
@@ -30,8 +32,6 @@ pub struct UserRole {
 pub struct OauthClientIdentifier {
     pub identifier: String,
 }
-
-pub type AuthorizationCode = String;
 
 #[derive(Debug, Deserialize, PartialEq, Serialize)]
 pub struct SessionToken {

--- a/identity/src/lib/rpc/server.rs
+++ b/identity/src/lib/rpc/server.rs
@@ -6,7 +6,9 @@ use diesel::prelude::*;
 use diesel::r2d2::{ConnectionManager, PooledConnection};
 use tarpc::context;
 
-use super::service::*;
+use helpers::rpc::{Error, RpcResult};
+
+use super::{models::*, service::IdentityService};
 use crate::authentication::oauth;
 use crate::config::Configuration;
 use crate::db::{models, Db};

--- a/identity/src/lib/rpc/service.rs
+++ b/identity/src/lib/rpc/service.rs
@@ -1,6 +1,6 @@
-use serde::{Deserialize, Serialize};
-
 pub use helpers::rpc::{Error, RpcResult};
+
+use super::models::*;
 
 #[tarpc::service]
 pub trait IdentityService {
@@ -20,52 +20,4 @@ pub trait IdentityService {
     async fn oauth_client_identifier() -> RpcResult<OauthClientIdentifier>;
     async fn oauth_authentication(code: AuthorizationCode) -> RpcResult<SessionToken>;
     async fn session_info(token: String) -> RpcResult<SessionInfo>;
-}
-
-#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
-pub struct User {
-    pub id: i32,
-    pub sub: String,
-    pub email: String,
-    pub given_name: String,
-    pub family_name: String,
-    pub picture: String,
-    pub active: bool,
-}
-
-#[derive(Debug, Deserialize, PartialEq, Serialize)]
-pub struct Role {
-    pub id: i32,
-    pub name: String,
-    pub access_manage_books: bool,
-    pub access_manage_roles: bool,
-}
-
-#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
-pub struct UserRole {
-    pub id: i32,
-    pub user_id: i32,
-    pub role_id: i32,
-}
-
-#[derive(Debug, Deserialize, PartialEq, Serialize)]
-pub struct OauthClientIdentifier {
-    pub identifier: String,
-}
-
-pub type AuthorizationCode = String;
-
-#[derive(Debug, Deserialize, PartialEq, Serialize)]
-pub struct SessionToken {
-    pub token: String,
-}
-
-#[derive(Debug, Deserialize, PartialEq, Serialize)]
-pub struct SessionInfo {
-    pub sub: u32,
-    pub given_name: String,
-    pub family_name: String,
-    pub picture: String,
-    pub iat: u64,
-    pub exp: u64,
 }

--- a/identity/tests/rpc_endpoints.rs
+++ b/identity/tests/rpc_endpoints.rs
@@ -8,7 +8,7 @@ use tarpc::context;
 
 use helpers::rpc::Error;
 use identity::db::schema::{users::dsl::users, users_roles::dsl::users_roles};
-use identity::rpc::service::{Role, SessionInfo, User, UserRole};
+use identity::rpc::models::{Role, SessionInfo, User, UserRole};
 use identity::rpc::{rpc_client, rpc_server, service::IdentityServiceClient};
 use identity::{config::Configuration, db::Db, session::jwt::Jwt};
 


### PR DESCRIPTION
This PR moves the rpc models from `service.rs` into `models.rs` to better separate them.