### PR TITLE
Refactor/identity service initialization

### DIFF
--- a/identity/src/lib/config.rs
+++ b/identity/src/lib/config.rs
@@ -1,5 +1,6 @@
 use std::net::{IpAddr, SocketAddr};
 
+use dotenv::dotenv;
 use envconfig::Envconfig;
 
 #[derive(Envconfig, Debug, Clone)]
@@ -54,4 +55,9 @@ impl Configuration {
     pub fn jwt_secret(&self) -> String {
         self.jwt_secret.clone()
     }
+}
+
+pub fn configuration() -> Configuration {
+    dotenv().ok();
+    Configuration::init_from_env().expect("Failed to create configuration")
 }

--- a/identity/src/lib/config.rs
+++ b/identity/src/lib/config.rs
@@ -57,7 +57,7 @@ impl Configuration {
     }
 }
 
-pub fn configuration() -> Configuration {
+pub fn get_configuration() -> Configuration {
     dotenv().ok();
     Configuration::init_from_env().expect("Failed to create configuration")
 }

--- a/identity/src/lib/db/mod.rs
+++ b/identity/src/lib/db/mod.rs
@@ -6,3 +6,7 @@ use diesel::r2d2::{ConnectionManager, Pool, PooledConnection};
 
 pub type DbPool = Pool<ConnectionManager<PgConnection>>;
 pub type DbConn = PooledConnection<ConnectionManager<PgConnection>>;
+
+pub fn db_pool(database_url: &str) -> DbPool {
+    Pool::new(ConnectionManager::new(database_url)).expect("Failed to create database pool")
+}

--- a/identity/src/lib/db/mod.rs
+++ b/identity/src/lib/db/mod.rs
@@ -7,6 +7,6 @@ use diesel::r2d2::{ConnectionManager, Pool, PooledConnection};
 pub type DbPool = Pool<ConnectionManager<PgConnection>>;
 pub type DbConn = PooledConnection<ConnectionManager<PgConnection>>;
 
-pub fn db_pool(database_url: &str) -> DbPool {
+pub fn get_db_pool(database_url: &str) -> DbPool {
     Pool::new(ConnectionManager::new(database_url)).expect("Failed to create database pool")
 }

--- a/identity/src/lib/db/mod.rs
+++ b/identity/src/lib/db/mod.rs
@@ -2,6 +2,7 @@ pub mod models;
 pub mod schema;
 
 use diesel::prelude::*;
-use diesel::r2d2::{ConnectionManager, Pool};
+use diesel::r2d2::{ConnectionManager, Pool, PooledConnection};
 
-pub type Db = Pool<ConnectionManager<PgConnection>>;
+pub type DbPool = Pool<ConnectionManager<PgConnection>>;
+pub type DbConn = PooledConnection<ConnectionManager<PgConnection>>;

--- a/identity/src/lib/rpc/mod.rs
+++ b/identity/src/lib/rpc/mod.rs
@@ -11,12 +11,12 @@ use tokio_serde::formats::Json;
 
 use self::server::IdentityServer;
 use self::service::{IdentityService, IdentityServiceClient};
-use crate::{config::Configuration, db::Db};
+use crate::{config::Configuration, db::DbPool};
 
 pub async fn rpc_server(
     addr: SocketAddr,
     configuration: Arc<Configuration>,
-    db: Arc<Db>,
+    db_pool: Arc<DbPool>,
 ) -> io::Result<(impl Future<Output = ()>, SocketAddr)> {
     let incoming = tarpc::serde_transport::tcp::listen(&addr, Json::default).await?;
     let addr = incoming.local_addr();
@@ -29,7 +29,7 @@ pub async fn rpc_server(
             let server = IdentityServer {
                 addr: channel.as_ref().as_ref().peer_addr().unwrap(),
                 conf: configuration.clone(),
-                db: db.clone(),
+                db_pool: db_pool.clone(),
             };
             channel.respond_with(server.serve()).execute()
         })

--- a/identity/src/lib/rpc/mod.rs
+++ b/identity/src/lib/rpc/mod.rs
@@ -26,11 +26,11 @@ pub async fn rpc_server(
         .map(BaseChannel::with_defaults)
         .max_channels_per_key(1, |t| t.as_ref().peer_addr().unwrap().ip())
         .map(move |channel| {
-            let server = IdentityServer {
-                addr: channel.as_ref().as_ref().peer_addr().unwrap(),
-                conf: configuration.clone(),
-                db_pool: db_pool.clone(),
-            };
+            let server = IdentityServer::new(
+                channel.as_ref().as_ref().peer_addr().unwrap(),
+                configuration.clone(),
+                db_pool.clone(),
+            );
             channel.respond_with(server.serve()).execute()
         })
         .buffer_unordered(10)

--- a/identity/src/lib/rpc/mod.rs
+++ b/identity/src/lib/rpc/mod.rs
@@ -13,7 +13,7 @@ use self::server::IdentityServer;
 use self::service::{IdentityService, IdentityServiceClient};
 use crate::{config::Configuration, db::DbPool};
 
-pub async fn rpc_server(
+pub async fn get_rpc_server(
     addr: SocketAddr,
     configuration: Arc<Configuration>,
     db_pool: Arc<DbPool>,
@@ -39,7 +39,7 @@ pub async fn rpc_server(
     Ok((fut, addr))
 }
 
-pub async fn rpc_client(addr: SocketAddr) -> std::io::Result<IdentityServiceClient> {
+pub async fn get_rpc_client(addr: SocketAddr) -> std::io::Result<IdentityServiceClient> {
     IdentityServiceClient::new(
         Config::default(),
         tarpc::serde_transport::tcp::connect(addr, Json::default).await?,

--- a/identity/src/lib/rpc/server.rs
+++ b/identity/src/lib/rpc/server.rs
@@ -11,19 +11,21 @@ use helpers::rpc::{Error, RpcResult};
 use super::{models::*, service::IdentityService};
 use crate::authentication::oauth;
 use crate::config::Configuration;
-use crate::db::{models, Db};
+use crate::db::{models, DbPool};
 use crate::session::jwt::Jwt;
 
 #[derive(Clone)]
 pub struct IdentityServer {
     pub addr: SocketAddr,
     pub conf: Arc<Configuration>,
-    pub db: Arc<Db>,
+    pub db_pool: Arc<DbPool>,
 }
 
 impl IdentityServer {
     fn get_db(&self) -> PooledConnection<ConnectionManager<PgConnection>> {
-        self.db.get().expect("Can't retrieve connection from pool")
+        self.db_pool
+            .get()
+            .expect("Can't retrieve connection from pool")
     }
 }
 

--- a/identity/src/lib/rpc/server.rs
+++ b/identity/src/lib/rpc/server.rs
@@ -16,12 +16,20 @@ use crate::session::jwt::Jwt;
 
 #[derive(Clone)]
 pub struct IdentityServer {
-    pub addr: SocketAddr,
-    pub conf: Arc<Configuration>,
-    pub db_pool: Arc<DbPool>,
+    addr: SocketAddr,
+    conf: Arc<Configuration>,
+    db_pool: Arc<DbPool>,
 }
 
 impl IdentityServer {
+    pub fn new(addr: SocketAddr, conf: Arc<Configuration>, db_pool: Arc<DbPool>) -> Self {
+        Self {
+            addr,
+            conf,
+            db_pool,
+        }
+    }
+
     fn get_db(&self) -> PooledConnection<ConnectionManager<PgConnection>> {
         self.db_pool
             .get()

--- a/identity/src/main.rs
+++ b/identity/src/main.rs
@@ -8,7 +8,7 @@ use envconfig::Envconfig;
 extern crate diesel_migrations;
 
 use identity::config::Configuration;
-use identity::db::Db;
+use identity::db::DbPool;
 use identity::rpc::rpc_server;
 
 #[tokio::main]
@@ -33,7 +33,7 @@ async fn main() -> io::Result<()> {
         }
     };
 
-    let db: Arc<Db> = {
+    let db: Arc<DbPool> = {
         match Pool::new(ConnectionManager::new(configuration.db_connection_url())) {
             Ok(val) => Arc::new(val),
             Err(e) => {

--- a/identity/src/main.rs
+++ b/identity/src/main.rs
@@ -4,7 +4,7 @@ use std::{io, sync::Arc};
 extern crate diesel_migrations;
 
 use helpers::db::run_migration;
-use identity::{config::configuration, db::db_pool, rpc::rpc_server};
+use identity::{config::get_configuration, db::get_db_pool, rpc::get_rpc_server};
 
 #[tokio::main]
 async fn main() -> io::Result<()> {
@@ -16,14 +16,14 @@ async fn main() -> io::Result<()> {
     env_logger::init();
     log::info!("Starting service");
 
-    let configuration = configuration();
+    let configuration = get_configuration();
 
-    let db_pool = db_pool(&configuration.db_connection_url());
+    let db_pool = get_db_pool(&configuration.db_connection_url());
 
     embed_migrations!();
     run_migration(embedded_migrations::run, &db_pool);
 
-    let (server, addr) = rpc_server(
+    let (server, addr) = get_rpc_server(
         configuration.rpc_socket(),
         Arc::new(configuration),
         Arc::new(db_pool),

--- a/identity/src/main.rs
+++ b/identity/src/main.rs
@@ -11,15 +11,12 @@ use identity::config::Configuration;
 use identity::db::Db;
 use identity::rpc::rpc_server;
 
-static PKG_NAME: Option<&'static str> = option_env!("CARGO_PKG_NAME");
-static PKG_VERSION: Option<&'static str> = option_env!("CARGO_PKG_VERSION");
-
 #[tokio::main]
 async fn main() -> io::Result<()> {
     println!(
         "SERVICE: {} | VERSION: {}\n",
-        PKG_NAME.unwrap_or("<unknown>"),
-        PKG_VERSION.unwrap_or("<unknown>")
+        option_env!("CARGO_PKG_NAME").unwrap_or("<unknown>"),
+        option_env!("CARGO_PKG_VERSION").unwrap_or("<unknown>")
     );
     env_logger::init();
     log::info!("Starting service");

--- a/identity/src/main.rs
+++ b/identity/src/main.rs
@@ -3,8 +3,8 @@ use std::{io, sync::Arc};
 #[macro_use]
 extern crate diesel_migrations;
 
-use identity::config::{configuration, Configuration};
-use identity::db::{db_pool, DbPool};
+use identity::config::configuration;
+use identity::db::db_pool;
 use identity::rpc::rpc_server;
 
 #[tokio::main]
@@ -17,17 +17,17 @@ async fn main() -> io::Result<()> {
     env_logger::init();
     log::info!("Starting service");
 
-    let configuration: Arc<Configuration> = Arc::new(configuration());
+    let configuration = configuration();
 
-    let db_pool: Arc<DbPool> = Arc::new(db_pool(&configuration.db_connection_url()));
+    let db_pool = db_pool(&configuration.db_connection_url());
 
     embed_migrations!();
     helpers::db::run_migration(embedded_migrations::run, &db_pool);
 
     let (server, addr) = rpc_server(
         configuration.rpc_socket(),
-        configuration.clone(),
-        db_pool.clone(),
+        Arc::new(configuration),
+        Arc::new(db_pool),
     )
     .await
     .unwrap();

--- a/identity/src/main.rs
+++ b/identity/src/main.rs
@@ -3,6 +3,7 @@ use std::{io, sync::Arc};
 #[macro_use]
 extern crate diesel_migrations;
 
+use helpers::db::run_migration;
 use identity::{config::configuration, db::db_pool, rpc::rpc_server};
 
 #[tokio::main]
@@ -20,7 +21,7 @@ async fn main() -> io::Result<()> {
     let db_pool = db_pool(&configuration.db_connection_url());
 
     embed_migrations!();
-    helpers::db::run_migration(embedded_migrations::run, &db_pool);
+    run_migration(embedded_migrations::run, &db_pool);
 
     let (server, addr) = rpc_server(
         configuration.rpc_socket(),

--- a/identity/src/main.rs
+++ b/identity/src/main.rs
@@ -3,9 +3,7 @@ use std::{io, sync::Arc};
 #[macro_use]
 extern crate diesel_migrations;
 
-use identity::config::configuration;
-use identity::db::db_pool;
-use identity::rpc::rpc_server;
+use identity::{config::configuration, db::db_pool, rpc::rpc_server};
 
 #[tokio::main]
 async fn main() -> io::Result<()> {

--- a/identity/src/main.rs
+++ b/identity/src/main.rs
@@ -1,12 +1,9 @@
-use std::{io, process, sync::Arc};
-
-use dotenv::dotenv;
-use envconfig::Envconfig;
+use std::{io, sync::Arc};
 
 #[macro_use]
 extern crate diesel_migrations;
 
-use identity::config::Configuration;
+use identity::config::{configuration, Configuration};
 use identity::db::{db_pool, DbPool};
 use identity::rpc::rpc_server;
 
@@ -20,17 +17,7 @@ async fn main() -> io::Result<()> {
     env_logger::init();
     log::info!("Starting service");
 
-    let configuration: Arc<Configuration> = {
-        dotenv().ok();
-        match Configuration::init_from_env() {
-            Ok(val) => Arc::new(val),
-            Err(e) => {
-                log::error!("{}", e);
-                log::error!("Terminating because of previous error.");
-                process::exit(1);
-            }
-        }
-    };
+    let configuration: Arc<Configuration> = Arc::new(configuration());
 
     let db_pool: Arc<DbPool> = Arc::new(db_pool(&configuration.db_connection_url()));
 

--- a/identity/tests/rpc_endpoints.rs
+++ b/identity/tests/rpc_endpoints.rs
@@ -2,15 +2,15 @@ use std::env::set_var;
 use std::sync::Arc;
 
 use diesel::prelude::*;
-use diesel::r2d2::{ConnectionManager, Pool};
 use envconfig::Envconfig;
 use tarpc::context;
 
 use helpers::rpc::Error;
+use identity::db::db_pool;
 use identity::db::schema::{users::dsl::users, users_roles::dsl::users_roles};
 use identity::rpc::models::{Role, SessionInfo, User, UserRole};
 use identity::rpc::{rpc_client, rpc_server, service::IdentityServiceClient};
-use identity::{config::Configuration, db::DbPool, session::jwt::Jwt};
+use identity::{config::Configuration, session::jwt::Jwt};
 
 mod sample_data;
 
@@ -105,8 +105,7 @@ async fn setup(
     let configuration = Arc::new(get_test_configuration());
     let db_test_context =
         DbTestContext::new(configuration.db_connection_base_url(), test_context_name);
-    let db: Arc<DbPool> =
-        Arc::new(Pool::new(ConnectionManager::new(db_test_context.get_connection_url())).unwrap());
+    let db = Arc::new(db_pool(&db_test_context.get_connection_url()));
     let (server, socket) = rpc_server(
         configuration.rpc_socket(),
         configuration.clone(),

--- a/identity/tests/rpc_endpoints.rs
+++ b/identity/tests/rpc_endpoints.rs
@@ -6,10 +6,10 @@ use envconfig::Envconfig;
 use tarpc::context;
 
 use helpers::rpc::Error;
-use identity::db::db_pool;
+use identity::db::get_db_pool;
 use identity::db::schema::{users::dsl::users, users_roles::dsl::users_roles};
 use identity::rpc::models::{Role, SessionInfo, User, UserRole};
-use identity::rpc::{rpc_client, rpc_server, service::IdentityServiceClient};
+use identity::rpc::{get_rpc_client, get_rpc_server, service::IdentityServiceClient};
 use identity::{config::Configuration, session::jwt::Jwt};
 
 mod sample_data;
@@ -105,15 +105,15 @@ async fn setup(
     let configuration = Arc::new(get_test_configuration());
     let db_test_context =
         DbTestContext::new(configuration.db_connection_base_url(), test_context_name);
-    let db = Arc::new(db_pool(&db_test_context.get_connection_url()));
-    let (server, socket) = rpc_server(
+    let db = Arc::new(get_db_pool(&db_test_context.get_connection_url()));
+    let (server, socket) = get_rpc_server(
         configuration.rpc_socket(),
         configuration.clone(),
         db.clone(),
     )
     .await
     .unwrap();
-    let client = rpc_client(socket).await.unwrap();
+    let client = get_rpc_client(socket).await.unwrap();
 
     Ok((server, client, configuration, db_test_context))
 }

--- a/identity/tests/rpc_endpoints.rs
+++ b/identity/tests/rpc_endpoints.rs
@@ -10,7 +10,7 @@ use helpers::rpc::Error;
 use identity::db::schema::{users::dsl::users, users_roles::dsl::users_roles};
 use identity::rpc::models::{Role, SessionInfo, User, UserRole};
 use identity::rpc::{rpc_client, rpc_server, service::IdentityServiceClient};
-use identity::{config::Configuration, db::Db, session::jwt::Jwt};
+use identity::{config::Configuration, db::DbPool, session::jwt::Jwt};
 
 mod sample_data;
 
@@ -105,7 +105,7 @@ async fn setup(
     let configuration = Arc::new(get_test_configuration());
     let db_test_context =
         DbTestContext::new(configuration.db_connection_base_url(), test_context_name);
-    let db: Arc<Db> =
+    let db: Arc<DbPool> =
         Arc::new(Pool::new(ConnectionManager::new(db_test_context.get_connection_url())).unwrap());
     let (server, socket) = rpc_server(
         configuration.rpc_socket(),


### PR DESCRIPTION
This change is simplifying the service initialization in `main.rs` by moving parts into their respective sub-modules and providing functions for initialization. Also, the types for `DbPool` and `DbConn`, like in the book service are introduced.