### PR TITLE
`book`: Simplify models through serde magic

### DIFF
--- a/book/src/lib/db/models.rs
+++ b/book/src/lib/db/models.rs
@@ -2,22 +2,25 @@ use chrono::NaiveDate;
 use diesel::Queryable;
 use serde::{Deserialize, Serialize};
 
-#[derive(Clone, Debug, Queryable)]
+#[derive(Clone, Debug, Deserialize, Queryable, Serialize)]
 pub struct Book {
     pub id: i32,
     /// E.g. `SE20`, `STS5`
-    pub code_identifier: String,
+    code_identifier: String,
     /// International Standard Book Number (https://en.wikipedia.org/wiki/International_Standard_Book_Number)
-    pub isbn: String,
+    isbn: String,
     /// International Standard Serial Number (https://en.wikipedia.org/wiki/International_Standard_Serial_Number)
-    pub issn: Option<String>,
-    pub release_date: NaiveDate,
-    pub subtitle: Option<String>,
-    pub title: String,
+    issn: Option<String>,
+    release_date: NaiveDate,
+    subtitle: Option<String>,
+    title: String,
 
-    pub category_id: i32,
-    pub language_id: i32,
-    pub publisher_id: i32,
+    #[serde(skip)]
+    category_id: i32,
+    #[serde(skip)]
+    language_id: i32,
+    #[serde(skip)]
+    publisher_id: i32,
 }
 
 #[derive(Clone, Debug, Deserialize, Queryable, Serialize)]

--- a/book/src/lib/rpc/models.rs
+++ b/book/src/lib/rpc/models.rs
@@ -1,4 +1,3 @@
-use chrono::NaiveDate;
 use serde::{Deserialize, Serialize};
 
 pub use helpers::rpc::{Error, RpcResult};
@@ -8,26 +7,18 @@ pub use crate::db::models::*;
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Book {
-    pub id: i32,
-    /// E.g. SE20, STS5
-    pub code_identifier: String,
-    /// International Standard Book Number (https://en.wikipedia.org/wiki/International_Standard_Book_Number)
-    pub isbn: String,
-    /// International Standard Serial Number (https://en.wikipedia.org/wiki/International_Standard_Serial_Number)
-    pub issn: Option<String>,
-    pub release_date: NaiveDate,
-    pub subtitle: Option<String>,
-    pub title: String,
+    #[serde(flatten)]
+    raw_book: RawBook,
 
     // one-to-many
-    pub category: Category,
-    pub language: Language,
-    pub publisher: Publisher,
-    pub series: Option<Series>,
+    category: Category,
+    language: Language,
+    publisher: Publisher,
+    series: Option<Series>,
 
     // many-to-many
-    pub authors: Vec<Person>,
-    pub subject_areas: Vec<SubjectArea>,
+    authors: Vec<Person>,
+    subject_areas: Vec<SubjectArea>,
 }
 
 impl Book {
@@ -41,13 +32,7 @@ impl Book {
         subject_areas: Vec<SubjectArea>,
     ) -> Self {
         Self {
-            id: raw_book.id,
-            code_identifier: raw_book.code_identifier,
-            isbn: raw_book.isbn,
-            issn: raw_book.issn,
-            release_date: raw_book.release_date,
-            subtitle: raw_book.subtitle,
-            title: raw_book.title,
+            raw_book,
             category,
             language,
             publisher,
@@ -55,6 +40,10 @@ impl Book {
             authors,
             subject_areas,
         }
+    }
+
+    pub fn id(&self) -> i32 {
+        self.raw_book.id
     }
 
     pub fn push_author(&mut self, a: Person) {

--- a/book/src/lib/rpc/server.rs
+++ b/book/src/lib/rpc/server.rs
@@ -60,8 +60,8 @@ impl BookService for BookServer {
         let mut book_map: HashMap<i32, Book> = HashMap::with_capacity(book_list.len());
         for (b, c, l, p) in book_list.into_iter() {
             let new_book = Book::new(b, c, l, p, None, Vec::new(), Vec::new());
-            if let Some(err_book) = book_map.insert(new_book.id, new_book) {
-                panic!("Duplicate book id: {}", err_book.id);
+            if let Some(err_book) = book_map.insert(new_book.id(), new_book) {
+                panic!("Duplicate book id: {}", err_book.id());
             }
         }
 


### PR DESCRIPTION
This PR uses serde field attributes ([see here](https://serde.rs/field-attrs.html)) to remove state duplication in the book service.