### PR TITLE
Identity oauth refactoring

### DIFF
--- a/identity/src/lib/authentication/mod.rs
+++ b/identity/src/lib/authentication/mod.rs
@@ -3,8 +3,8 @@ pub mod oauth;
 use chrono::{Duration, NaiveDateTime};
 use diesel::result::{Error, QueryResult};
 
+use self::oauth::{IdToken, TokenSet};
 use crate::db::models::{User, UserAddUpdate};
-use oauth::{IdToken, TokenSet};
 
 #[derive(Debug, PartialEq)]
 pub enum AccountStatus {

--- a/identity/src/lib/authentication/mod.rs
+++ b/identity/src/lib/authentication/mod.rs
@@ -1,1 +1,74 @@
 pub mod oauth;
+
+use diesel::result::{Error, QueryResult};
+
+use crate::db::models::User;
+
+#[derive(Debug, PartialEq)]
+pub enum AccountStatus {
+    Active,
+    Inactive,
+    New,
+}
+
+pub fn check_account_status(query_result: QueryResult<User>) -> Result<AccountStatus, Error> {
+    unimplemented!();
+}
+
+#[cfg(test)]
+mod tests {
+    use chrono::NaiveDate;
+
+    use super::*;
+
+    // check for active account
+    #[test]
+    fn check_active_account() {
+        let query_result = Ok(User {
+            id: 1,
+            sub: "1".into(),
+            email: "john.doe@example.net".into(),
+            given_name: "John".into(),
+            family_name: "Doe".into(),
+            picture: "https://example.com/avatar.jpg".into(),
+            oauth_access_token: "access_token".into(),
+            oauth_access_token_valid: NaiveDate::from_ymd(2020, 12, 31).and_hms(0, 0, 0),
+            oauth_refresh_token: "refresh_token".into(),
+            active: true,
+        });
+
+        assert_eq!(
+            Ok(AccountStatus::Active),
+            check_account_status(query_result)
+        );
+    }
+
+    // check for inactive account
+    #[test]
+    fn check_inactive_account() {
+        let query_result = Ok(User {
+            id: 1,
+            sub: "1".into(),
+            email: "john.doe@example.net".into(),
+            given_name: "John".into(),
+            family_name: "Doe".into(),
+            picture: "https://example.com/avatar.jpg".into(),
+            oauth_access_token: "access_token".into(),
+            oauth_access_token_valid: NaiveDate::from_ymd(2020, 12, 31).and_hms(0, 0, 0),
+            oauth_refresh_token: "refresh_token".into(),
+            active: false,
+        });
+
+        assert_eq!(
+            Ok(AccountStatus::Inactive),
+            check_account_status(query_result)
+        );
+    }
+
+    // check for new account
+    #[test]
+    fn check_new_account() {
+        let query_result = Err(Error::NotFound);
+        assert_eq!(Ok(AccountStatus::New), check_account_status(query_result));
+    }
+}

--- a/identity/src/lib/authentication/mod.rs
+++ b/identity/src/lib/authentication/mod.rs
@@ -12,7 +12,17 @@ pub enum AccountStatus {
 }
 
 pub fn check_account_status(query_result: QueryResult<User>) -> Result<AccountStatus, Error> {
-    unimplemented!();
+    match query_result {
+        Ok(val) => {
+            if val.active {
+                Ok(AccountStatus::Active)
+            } else {
+                Ok(AccountStatus::Inactive)
+            }
+        }
+        Err(Error::NotFound) => Ok(AccountStatus::New),
+        Err(e) => Err(e),
+    }
 }
 
 #[cfg(test)]

--- a/identity/src/lib/authentication/mod.rs
+++ b/identity/src/lib/authentication/mod.rs
@@ -32,7 +32,17 @@ pub fn create_user_from_oauth_authentication(
     token_set: &TokenSet,
     creation_time: NaiveDateTime,
 ) -> UserAddUpdate {
-    unimplemented!()
+    UserAddUpdate {
+        sub: id_token.sub.clone(),
+        email: id_token.email.clone(),
+        given_name: id_token.given_name.clone(),
+        family_name: id_token.family_name.clone(),
+        picture: id_token.picture.clone(),
+        oauth_access_token: token_set.access_token.clone(),
+        oauth_access_token_valid: creation_time + Duration::seconds(token_set.expires_in.into()),
+        oauth_refresh_token: token_set.refresh_token.clone(),
+        active: true,
+    }
 }
 
 #[cfg(test)]

--- a/identity/src/lib/authentication/oauth.rs
+++ b/identity/src/lib/authentication/oauth.rs
@@ -1,8 +1,9 @@
-use helpers::rpc::Error as RpcError;
 use hyper::{Body, Client, Request, StatusCode, Uri};
 use hyper_tls::HttpsConnector;
 use jsonwebtoken::dangerous_insecure_decode;
 use serde::{Deserialize, Serialize, Serializer};
+
+use helpers::rpc::Error as RpcError;
 
 type ClientIdentifier = String;
 type ClientSecret = String;

--- a/identity/src/lib/authentication/oauth.rs
+++ b/identity/src/lib/authentication/oauth.rs
@@ -28,7 +28,7 @@ impl From<Error> for RpcError {
             Error::TokenRequestEndpointNotReachable => RpcError::InternalError,
             Error::TokenRequestContentInvalid => RpcError::InternalError,
             Error::TokenRequestDeserialization => RpcError::InternalError,
-            _ => RpcError::InternalError,
+            Error::IdTokenInvalid => RpcError::InternalError,
         }
     }
 }

--- a/identity/src/lib/authentication/oauth.rs
+++ b/identity/src/lib/authentication/oauth.rs
@@ -21,15 +21,11 @@ pub enum Error {
 
 impl From<Error> for RpcError {
     fn from(e: Error) -> Self {
+        use Error::*;
         log::debug!("{:?}", e);
         match e {
-            Error::AuthorizationCodeLength => RpcError::InvalidData,
-            Error::AuthorizationCodeInvalidCharacter => RpcError::InvalidData,
-            Error::TokenRequestEndpointInvalidResponse => RpcError::InternalError,
-            Error::TokenRequestEndpointNotReachable => RpcError::InternalError,
-            Error::TokenRequestContentInvalid => RpcError::InternalError,
-            Error::TokenRequestDeserialization => RpcError::InternalError,
-            Error::IdTokenInvalid => RpcError::InternalError,
+            AuthorizationCodeLength | AuthorizationCodeInvalidCharacter => RpcError::InvalidData,
+            _ => RpcError::InternalError,
         }
     }
 }

--- a/identity/src/lib/authentication/oauth.rs
+++ b/identity/src/lib/authentication/oauth.rs
@@ -22,6 +22,8 @@ impl From<Error> for RpcError {
     fn from(e: Error) -> Self {
         log::debug!("{:?}", e);
         match e {
+            Error::AuthorizationCodeLength => RpcError::InvalidData,
+            Error::AuthorizationCodeInvalidCharacter => RpcError::InvalidData,
             _ => RpcError::InternalError,
         }
     }

--- a/identity/src/lib/authentication/oauth.rs
+++ b/identity/src/lib/authentication/oauth.rs
@@ -1,3 +1,4 @@
+use helpers::rpc::Error as RpcError;
 use hyper::{Body, Client, Request, StatusCode, Uri};
 use hyper_tls::HttpsConnector;
 use jsonwebtoken::dangerous_insecure_decode;
@@ -15,6 +16,15 @@ pub enum Error {
     TokenRequestContentInvalid,
     TokenRequestDeserialization,
     IdTokenInvalid,
+}
+
+impl From<Error> for RpcError {
+    fn from(e: Error) -> Self {
+        log::debug!("{:?}", e);
+        match e {
+            _ => RpcError::InternalError,
+        }
+    }
 }
 
 pub struct DiscoveryDocument {}

--- a/identity/src/lib/authentication/oauth.rs
+++ b/identity/src/lib/authentication/oauth.rs
@@ -34,9 +34,12 @@ impl From<Error> for RpcError {
     }
 }
 
+/// Represents the Google Discovery Document
+/// https://accounts.google.com/.well-known/openid-configuration
 pub struct DiscoveryDocument {}
 
 impl DiscoveryDocument {
+    /// Returns the `token_endpoint` key value
     pub fn get_token_endpoint() -> Uri {
         "https://oauth2.googleapis.com/token".parse().unwrap()
     }

--- a/identity/src/lib/authentication/oauth.rs
+++ b/identity/src/lib/authentication/oauth.rs
@@ -17,6 +17,14 @@ pub enum Error {
     IdTokenInvalid,
 }
 
+pub struct DiscoveryDocument {}
+
+impl DiscoveryDocument {
+    pub fn get_token_endpoint() -> Uri {
+        "https://oauth2.googleapis.com/token".parse().unwrap()
+    }
+}
+
 #[derive(Debug, PartialEq)]
 pub struct AuthorizationCode {
     code: String,

--- a/identity/src/lib/authentication/oauth.rs
+++ b/identity/src/lib/authentication/oauth.rs
@@ -24,6 +24,10 @@ impl From<Error> for RpcError {
         match e {
             Error::AuthorizationCodeLength => RpcError::InvalidData,
             Error::AuthorizationCodeInvalidCharacter => RpcError::InvalidData,
+            Error::TokenRequestEndpointInvalidResponse => RpcError::InternalError,
+            Error::TokenRequestEndpointNotReachable => RpcError::InternalError,
+            Error::TokenRequestContentInvalid => RpcError::InternalError,
+            Error::TokenRequestDeserialization => RpcError::InternalError,
             _ => RpcError::InternalError,
         }
     }

--- a/identity/src/lib/db/queries.rs
+++ b/identity/src/lib/db/queries.rs
@@ -17,6 +17,12 @@ pub fn get_user(user_id: i32, db: &DbConn) -> QueryResult<User> {
     users.find(user_id).first(db)
 }
 
+pub fn get_user_by_sub(sub: &str, db: &DbConn) -> QueryResult<User> {
+    use schema::users::dsl;
+
+    dsl::users.filter(dsl::sub.eq(sub)).get_result(db)
+}
+
 pub fn list_users(
     offset: i64,
     limit: i64,

--- a/identity/src/lib/db/queries.rs
+++ b/identity/src/lib/db/queries.rs
@@ -49,6 +49,14 @@ pub fn update_user(user: User, db: &DbConn) -> QueryResult<User> {
         .get_result(db)
 }
 
+pub fn update_user_by_sub(user: UserAddUpdate, db: &DbConn) -> QueryResult<User> {
+    use schema::users::dsl::*;
+
+    diesel::update(users.filter(sub.eq(&user.sub)))
+        .set(&user)
+        .get_result(db)
+}
+
 pub fn get_role(role_id: i32, db: &DbConn) -> QueryResult<Role> {
     use schema::roles::dsl::roles;
 

--- a/identity/src/lib/rpc/models.rs
+++ b/identity/src/lib/rpc/models.rs
@@ -2,7 +2,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::session::jwt::Jwt;
 
-pub type AuthorizationCode = String;
+pub type OauthAuthorizationCode = String;
 
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
 pub struct User {

--- a/identity/src/lib/rpc/server.rs
+++ b/identity/src/lib/rpc/server.rs
@@ -239,16 +239,9 @@ impl IdentityService for IdentityServer {
             oauth::GrantType::AuthorizationCode,
         );
 
-        let tokenset = match request
+        let tokenset = request
             .exchange_code(oauth::DiscoveryDocument::get_token_endpoint())
-            .await
-        {
-            Ok(val) => val,
-            Err(e) => {
-                println!("{:?}", e);
-                return Err(Error::InternalError);
-            }
-        };
+            .await?;
 
         let id_token = match oauth::IdToken::new(&tokenset.id_token) {
             Ok(val) => val,

--- a/identity/src/lib/rpc/server.rs
+++ b/identity/src/lib/rpc/server.rs
@@ -254,11 +254,11 @@ impl IdentityService for IdentityServer {
 
         // Checks if the user account is inactive or authentication has missing refresh token for new account
         if account_status == AccountStatus::Inactive {
-            log::info!("Rejected inactive account \"{}\"", &id_token.email);
+            log::info!("Rejected inactive account '{}'", &id_token.email);
             return Err(Error::InvalidInput);
         } else if account_status == AccountStatus::New && tokenset.refresh_token.is_none() {
-            log::info!("Rejected new account \"{}\"", &id_token.email);
-            log::info!("Missing refresh token for account \"{}\"", &id_token.email);
+            log::info!("Rejected new account '{}'", &id_token.email);
+            log::info!("Missing refresh token for account '{}'", &id_token.email);
             return Err(Error::InvalidInput);
         }
 
@@ -272,10 +272,7 @@ impl IdentityService for IdentityServer {
             AccountStatus::New => queries::create_user(user, &self.get_db())?,
             _ => return Err(Error::InternalError),
         };
-        log::info!(
-            "Successfully created/updated account \"{}\"",
-            &id_token.email
-        );
+        log::info!("Successfully created/updated account '{}'", &id_token.email);
 
         // Create and return SessionToken
         Ok(SessionToken {

--- a/identity/src/lib/rpc/server.rs
+++ b/identity/src/lib/rpc/server.rs
@@ -243,10 +243,7 @@ impl IdentityService for IdentityServer {
             .exchange_code(oauth::DiscoveryDocument::get_token_endpoint())
             .await?;
 
-        let id_token = match oauth::IdToken::new(&tokenset.id_token) {
-            Ok(val) => val,
-            Err(_) => return Err(Error::InternalError),
-        };
+        let id_token = oauth::IdToken::new(&tokenset.id_token)?;
 
         match users
             .filter(sub.eq(&id_token.sub))

--- a/identity/src/lib/rpc/server.rs
+++ b/identity/src/lib/rpc/server.rs
@@ -241,12 +241,11 @@ impl IdentityService for IdentityServer {
             oauth::RedirectUri::PostMessage,
             oauth::GrantType::AuthorizationCode,
         );
-        use hyper::Uri;
-        let token_endpoint = "https://oauth2.googleapis.com/token"
-            .parse::<Uri>()
-            .unwrap();
 
-        let tokenset = match request.exchange_code(token_endpoint).await {
+        let tokenset = match request
+            .exchange_code(oauth::DiscoveryDocument::get_token_endpoint())
+            .await
+        {
             Ok(val) => val,
             Err(e) => {
                 println!("{:?}", e);

--- a/identity/src/lib/rpc/server.rs
+++ b/identity/src/lib/rpc/server.rs
@@ -229,10 +229,7 @@ impl IdentityService for IdentityServer {
     ) -> RpcResult<SessionToken> {
         use crate::db::schema::users::dsl::*;
 
-        let authorization_code = match oauth::AuthorizationCode::new(code) {
-            Ok(val) => val,
-            Err(_) => return Err(Error::InvalidData),
-        };
+        let authorization_code = oauth::AuthorizationCode::new(code)?;
 
         let request = oauth::TokenRequest::new(
             authorization_code,

--- a/identity/src/lib/rpc/service.rs
+++ b/identity/src/lib/rpc/service.rs
@@ -18,6 +18,6 @@ pub trait IdentityService {
     ) -> RpcResult<Vec<UserRole>>;
     async fn update_user_role(user_role_update: UserRole) -> RpcResult<UserRole>;
     async fn oauth_client_identifier() -> RpcResult<OauthClientIdentifier>;
-    async fn oauth_authentication(code: AuthorizationCode) -> RpcResult<SessionToken>;
+    async fn oauth_authentication(code: OauthAuthorizationCode) -> RpcResult<SessionToken>;
     async fn session_info(token: String) -> RpcResult<SessionInfo>;
 }

--- a/identity/tests/db_queries.rs
+++ b/identity/tests/db_queries.rs
@@ -275,6 +275,46 @@ async fn db_update_user_verify() {
     assert_eq!(Ok(expected_result), result);
 }
 
+// verify update user by sub
+#[tokio::test]
+async fn db_update_user_by_sub_verify() {
+    // Arrange
+    let (_configuration, db_pool, _db_test_context) = setup(stdext::function_name!().into())
+        .await
+        .expect("Could not set up test environment");
+
+    let expected_result = User {
+        id: 2,
+        sub: "2".into(),
+        email: "jack.kerr@example.net".into(),
+        given_name: "Jack".into(),
+        family_name: "Kerr".into(),
+        picture: "https://example.com/avatar.jpg".into(),
+        oauth_access_token: "access_token_new".into(),
+        oauth_access_token_valid: NaiveDate::from_ymd(2020, 12, 31).and_hms(0, 0, 0),
+        oauth_refresh_token: "refresh_token".into(),
+        active: true,
+    };
+
+    let expected_change = UserAddUpdate {
+        sub: "2".into(),
+        email: "jack.kerr@example.net".into(),
+        given_name: "Jack".into(),
+        family_name: "Kerr".into(),
+        picture: "https://example.com/avatar.jpg".into(),
+        oauth_access_token: "access_token_new".into(),
+        oauth_access_token_valid: NaiveDate::from_ymd(2020, 12, 31).and_hms(0, 0, 0),
+        oauth_refresh_token: None,
+        active: true,
+    };
+
+    // Act
+    let result = queries::update_user_by_sub(expected_change, &db_pool.get().unwrap());
+
+    // Assert
+    assert_eq!(Ok(expected_result), result);
+}
+
 // get a valid role
 #[tokio::test]
 async fn db_get_role_exists() {

--- a/identity/tests/db_queries.rs
+++ b/identity/tests/db_queries.rs
@@ -149,6 +149,34 @@ async fn db_get_user_not_exists() {
     assert_eq!(Err(Error::NotFound), result);
 }
 
+// get an user by its sub
+#[tokio::test]
+async fn db_get_user_by_sub() {
+    // Arrange
+    let (_configuration, db_pool, _db_test_context) = setup(stdext::function_name!().into())
+        .await
+        .expect("Could not set up test environment");
+
+    let expected_result = User {
+        id: 2,
+        sub: "2".into(),
+        email: "jack.kerr@example.net".into(),
+        given_name: "Jack".into(),
+        family_name: "Kerr".into(),
+        picture: "https://example.com/avatar.jpg".into(),
+        oauth_access_token: "access_token".into(),
+        oauth_access_token_valid: NaiveDate::from_ymd(2020, 12, 31).and_hms(0, 0, 0),
+        oauth_refresh_token: "refresh_token".into(),
+        active: true,
+    };
+
+    // Act
+    let result = queries::get_user_by_sub("2", &db_pool.get().unwrap());
+
+    // Assert
+    assert_eq!(Ok(expected_result), result);
+}
+
 // list active users with offset/limit
 #[tokio::test]
 async fn db_list_users_exists_active() {

--- a/identity/tests/rpc_endpoints.rs
+++ b/identity/tests/rpc_endpoints.rs
@@ -343,6 +343,7 @@ async fn update_user_role_verify() {
 #[tokio::test]
 async fn oauth_authentication() {
     // Check if test requirements are met
+    // This test will silently fail if the envrionment variable "OAUTH_AUTHORIZATION_CODE" is not set
     let authorization_code = match var("OAUTH_AUTHORIZATION_CODE") {
         Ok(val) => val,
         Err(_) => return,

--- a/identity/tests/rpc_endpoints.rs
+++ b/identity/tests/rpc_endpoints.rs
@@ -339,10 +339,31 @@ async fn update_user_role_verify() {
     assert_eq!(Ok(expected_result), result);
 }
 
-/*
- * TODO: test oauth_authentication
- * Reason: Return of method is currently unpredictable, because it is based on time.
- */
+// test oauth authentication
+#[tokio::test]
+async fn oauth_authentication() {
+    // Check if test requirements are met
+    let authorization_code = match var("OAUTH_AUTHORIZATION_CODE") {
+        Ok(val) => val,
+        Err(_) => return,
+    };
+
+    // Arrange
+    let (server, mut client, _configuration, _db_test_context) =
+        setup(stdext::function_name!().into())
+            .await
+            .expect("Could not set up test environment");
+    tokio::spawn(server);
+
+    // Act
+    let result = client
+        .oauth_authentication(context::current(), authorization_code)
+        .await
+        .unwrap();
+
+    // Assert
+    assert!(result.is_ok());
+}
 
 // test client identifier
 #[tokio::test]


### PR DESCRIPTION
* Adds integration test for OAuth authentication rpc endpoint
* Various simplifications for rpc OAuth authentication endpoint
* Unifies error return from OAuth authentication to provide conversion to RpcError
* Adds `check_account_status` function
* Adds `create_user_from_oauth_authentication` function
* Adds db query to update user by `sub` attribute
* Adds comments to OAuth authentication rpc endpoint