### PR TITLE
Feature/identity simplify user roles

### DIFF
--- a/identity/migrations/2020-12-09-140000_drop_users_roles/down.sql
+++ b/identity/migrations/2020-12-09-140000_drop_users_roles/down.sql
@@ -1,0 +1,24 @@
+CREATE TABLE users_roles (
+    id SERIAL,
+    user_id INTEGER,
+    role_id INTEGER,
+    PRIMARY KEY (id),
+    FOREIGN KEY (user_id) REFERENCES users ON UPDATE CASCADE ON DELETE CASCADE,
+    FOREIGN KEY (role_id) REFERENCES roles ON UPDATE CASCADE ON DELETE CASCADE
+);
+
+DO
+$$
+DECLARE
+    f record;
+BEGIN
+    FOR f IN SELECT * FROM users
+    LOOP
+	    INSERT INTO users_roles (user_id, role_id) VALUES (f.id, f.role_id);
+    END LOOP;
+END;
+$$;
+
+ALTER TABLE users_roles ALTER COLUMN user_id SET NOT NULL;
+ALTER TABLE users_roles ALTER COLUMN role_id SET NOT NULL;
+ALTER TABLE users DROP COLUMN role_id;

--- a/identity/migrations/2020-12-09-140000_drop_users_roles/up.sql
+++ b/identity/migrations/2020-12-09-140000_drop_users_roles/up.sql
@@ -1,0 +1,17 @@
+ALTER TABLE users ADD COLUMN role_id INTEGER;
+ALTER TABLE users ADD FOREIGN KEY (role_id) REFERENCES roles;
+
+DO
+$$
+DECLARE
+    f record;
+BEGIN
+    FOR f IN SELECT * FROM users_roles
+    LOOP
+	    UPDATE users SET role_id = f.role_id WHERE id = f.user_id;
+    END LOOP;
+END;
+$$;
+
+ALTER TABLE users ALTER COLUMN role_id SET NOT NULL;
+DROP TABLE users_roles;

--- a/identity/src/lib/authentication/mod.rs
+++ b/identity/src/lib/authentication/mod.rs
@@ -42,6 +42,7 @@ pub fn create_user_from_oauth_authentication(
         oauth_access_token_valid: creation_time + Duration::seconds(token_set.expires_in.into()),
         oauth_refresh_token: token_set.refresh_token.clone(),
         active: true,
+        role_id: 1,
     }
 }
 
@@ -65,6 +66,7 @@ mod tests {
             oauth_access_token_valid: NaiveDate::from_ymd(2020, 12, 31).and_hms(0, 0, 0),
             oauth_refresh_token: "refresh_token".into(),
             active: true,
+            role_id: 1,
         });
 
         assert_eq!(
@@ -87,6 +89,7 @@ mod tests {
             oauth_access_token_valid: NaiveDate::from_ymd(2020, 12, 31).and_hms(0, 0, 0),
             oauth_refresh_token: "refresh_token".into(),
             active: false,
+            role_id: 1,
         });
 
         assert_eq!(
@@ -139,6 +142,7 @@ mod tests {
             oauth_access_token_valid: NaiveDate::from_ymd(2020, 1, 1).and_hms(0, 1, 40),
             oauth_refresh_token: token_set.refresh_token.clone(),
             active: true,
+            role_id: 1,
         };
 
         let result = create_user_from_oauth_authentication(&id_token, &token_set, creation_time);
@@ -183,6 +187,7 @@ mod tests {
             oauth_access_token_valid: NaiveDate::from_ymd(2020, 1, 1).and_hms(0, 1, 40),
             oauth_refresh_token: token_set.refresh_token.clone(),
             active: true,
+            role_id: 1,
         };
 
         let result = create_user_from_oauth_authentication(&id_token, &token_set, creation_time);

--- a/identity/src/lib/db/models.rs
+++ b/identity/src/lib/db/models.rs
@@ -15,6 +15,7 @@ pub struct User {
     pub oauth_access_token_valid: NaiveDateTime,
     pub oauth_refresh_token: String,
     pub active: bool,
+    pub role_id: i32,
 }
 
 impl From<RpcModels::User> for User {
@@ -30,6 +31,7 @@ impl From<RpcModels::User> for User {
             oauth_access_token_valid: Utc::now().naive_utc(),
             oauth_refresh_token: "".into(),
             active: user.active,
+            role_id: user.role_id,
         }
     }
 }
@@ -46,6 +48,7 @@ pub struct UserAddUpdate {
     pub oauth_access_token_valid: NaiveDateTime,
     pub oauth_refresh_token: Option<String>,
     pub active: bool,
+    pub role_id: i32,
 }
 
 #[derive(Clone, Debug, PartialEq, Queryable)]
@@ -54,28 +57,4 @@ pub struct Role {
     pub name: String,
     pub access_manage_books: bool,
     pub access_manage_roles: bool,
-}
-
-#[derive(Clone, Debug, PartialEq, Queryable)]
-pub struct UserRole {
-    pub id: i32,
-    pub user_id: i32,
-    pub role_id: i32,
-}
-
-impl From<RpcModels::UserRole> for UserRole {
-    fn from(user_role: RpcModels::UserRole) -> Self {
-        UserRole {
-            id: user_role.id,
-            user_id: user_role.user_id,
-            role_id: user_role.role_id,
-        }
-    }
-}
-
-#[derive(Clone, Debug, AsChangeset, Insertable, PartialEq)]
-#[table_name = "users_roles"]
-pub struct UserRoleAddUpdate {
-    pub user_id: i32,
-    pub role_id: i32,
 }

--- a/identity/src/lib/db/queries.rs
+++ b/identity/src/lib/db/queries.rs
@@ -68,35 +68,3 @@ pub fn list_roles(offset: i64, limit: i64, db: &DbConn) -> QueryResult<Vec<Role>
 
     roles.offset(offset).limit(limit).load(db)
 }
-
-pub fn get_user_role(user_role_id: i32, db: &DbConn) -> QueryResult<UserRole> {
-    use schema::users_roles::dsl::users_roles;
-
-    users_roles.find(user_role_id).first(db)
-}
-
-pub fn list_user_roles(
-    offset: i64,
-    limit: i64,
-    role_id: Option<i32>,
-    db: &DbConn,
-) -> QueryResult<Vec<UserRole>> {
-    use schema::users_roles::dsl;
-
-    match role_id {
-        Some(val) => dsl::users_roles
-            .filter(dsl::role_id.eq(val))
-            .offset(offset)
-            .limit(limit)
-            .load(db),
-        None => dsl::users_roles.offset(offset).limit(limit).load(db),
-    }
-}
-
-pub fn update_user_role(user_role: UserRole, db: &DbConn) -> QueryResult<UserRole> {
-    use schema::users_roles::dsl::*;
-
-    diesel::update(users_roles.find(user_role.id as i32))
-        .set(role_id.eq(user_role.role_id as i32))
-        .get_result(db)
-}

--- a/identity/src/lib/db/schema.rs
+++ b/identity/src/lib/db/schema.rs
@@ -25,7 +25,4 @@ table! {
 
 joinable!(users -> roles (role_id));
 
-allow_tables_to_appear_in_same_query!(
-    roles,
-    users,
-);
+allow_tables_to_appear_in_same_query!(roles, users,);

--- a/identity/src/lib/db/schema.rs
+++ b/identity/src/lib/db/schema.rs
@@ -19,18 +19,13 @@ table! {
         oauth_access_token_valid -> Timestamp,
         oauth_refresh_token -> Varchar,
         active -> Bool,
-    }
-}
-
-table! {
-    users_roles (id) {
-        id -> Int4,
-        user_id -> Int4,
         role_id -> Int4,
     }
 }
 
-joinable!(users_roles -> roles (role_id));
-joinable!(users_roles -> users (user_id));
+joinable!(users -> roles (role_id));
 
-allow_tables_to_appear_in_same_query!(roles, users, users_roles,);
+allow_tables_to_appear_in_same_query!(
+    roles,
+    users,
+);

--- a/identity/src/lib/rpc/models.rs
+++ b/identity/src/lib/rpc/models.rs
@@ -13,6 +13,7 @@ pub struct User {
     pub family_name: String,
     pub picture: String,
     pub active: bool,
+    pub role_id: i32,
 }
 
 #[derive(Debug, Deserialize, PartialEq, Serialize)]
@@ -21,13 +22,6 @@ pub struct Role {
     pub name: String,
     pub access_manage_books: bool,
     pub access_manage_roles: bool,
-}
-
-#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
-pub struct UserRole {
-    pub id: i32,
-    pub user_id: i32,
-    pub role_id: i32,
 }
 
 #[derive(Debug, Deserialize, PartialEq, Serialize)]

--- a/identity/src/lib/rpc/server.rs
+++ b/identity/src/lib/rpc/server.rs
@@ -57,6 +57,7 @@ impl IdentityService for IdentityServer {
                 family_name: val.family_name,
                 picture: val.picture,
                 active: val.active,
+                role_id: val.role_id,
             }),
             Err(diesel::result::Error::NotFound) => Err(Error::NotFound),
             Err(_) => Err(Error::InternalError),
@@ -84,6 +85,7 @@ impl IdentityService for IdentityServer {
                     family_name: x.family_name.clone(),
                     picture: x.picture.clone(),
                     active: x.active,
+                    role_id: x.role_id,
                 })
                 .collect::<Vec<User>>()),
             Err(diesel::result::Error::NotFound) => Err(Error::NotFound),
@@ -120,6 +122,7 @@ impl IdentityService for IdentityServer {
                 family_name: val.family_name.clone(),
                 picture: val.picture.clone(),
                 active: val.active,
+                role_id: val.role_id,
             }),
             Err(diesel::result::Error::NotFound) => Err(Error::NotFound),
             Err(_) => Err(Error::InternalError),
@@ -145,72 +148,6 @@ impl IdentityService for IdentityServer {
                     access_manage_roles: x.access_manage_roles,
                 })
                 .collect::<Vec<Role>>()),
-            Err(diesel::result::Error::NotFound) => Err(Error::NotFound),
-            Err(_) => Err(Error::InternalError),
-        }
-    }
-
-    /// Returns an user role
-    async fn get_user_role(self, _: context::Context, user_role_id: u32) -> RpcResult<UserRole> {
-        let result = queries::get_user_role(user_role_id as i32, &self.get_db());
-
-        match result {
-            Ok(val) => Ok(UserRole {
-                id: val.id,
-                user_id: val.user_id,
-                role_id: val.role_id,
-            }),
-            Err(diesel::result::Error::NotFound) => Err(Error::NotFound),
-            Err(_) => Err(Error::InternalError),
-        }
-    }
-
-    /// Returns a list of users
-    async fn list_user_roles(
-        self,
-        _: context::Context,
-        offset: u32,
-        limit: u32,
-        role_id: Option<u32>,
-    ) -> RpcResult<Vec<UserRole>> {
-        let results = match role_id {
-            Some(val) => queries::list_user_roles(
-                offset.into(),
-                limit.into(),
-                Some(val as i32),
-                &self.get_db(),
-            ),
-            None => queries::list_user_roles(offset.into(), limit.into(), None, &self.get_db()),
-        };
-
-        match results {
-            Ok(val) => Ok(val
-                .iter()
-                .map(|x| UserRole {
-                    id: x.id,
-                    user_id: x.user_id,
-                    role_id: x.role_id,
-                })
-                .collect::<Vec<UserRole>>()),
-            Err(diesel::result::Error::NotFound) => Err(Error::NotFound),
-            Err(_) => Err(Error::InternalError),
-        }
-    }
-
-    /// Assigns a role to an user account
-    async fn update_user_role(
-        self,
-        _: context::Context,
-        user_role_update: UserRole,
-    ) -> RpcResult<UserRole> {
-        let result = queries::update_user_role(user_role_update.into(), &self.get_db());
-
-        match result {
-            Ok(val) => Ok(UserRole {
-                id: val.id,
-                user_id: val.user_id,
-                role_id: val.role_id,
-            }),
             Err(diesel::result::Error::NotFound) => Err(Error::NotFound),
             Err(_) => Err(Error::InternalError),
         }

--- a/identity/src/lib/rpc/service.rs
+++ b/identity/src/lib/rpc/service.rs
@@ -10,13 +10,6 @@ pub trait IdentityService {
     async fn update_user(user_update: User) -> RpcResult<User>;
     async fn get_role(role_id: u32) -> RpcResult<Role>;
     async fn list_roles(offset: u32, limit: u32) -> RpcResult<Vec<Role>>;
-    async fn get_user_role(user_role_id: u32) -> RpcResult<UserRole>;
-    async fn list_user_roles(
-        offset: u32,
-        limit: u32,
-        role_id: Option<u32>,
-    ) -> RpcResult<Vec<UserRole>>;
-    async fn update_user_role(user_role_update: UserRole) -> RpcResult<UserRole>;
     async fn oauth_client_identifier() -> RpcResult<OauthClientIdentifier>;
     async fn oauth_authentication(code: OauthAuthorizationCode) -> RpcResult<SessionToken>;
     async fn session_info(token: String) -> RpcResult<SessionInfo>;

--- a/identity/tests/db_queries.rs
+++ b/identity/tests/db_queries.rs
@@ -7,7 +7,7 @@ use diesel::{prelude::*, result::Error};
 use envconfig::Envconfig;
 
 use identity::config::Configuration;
-use identity::db::schema::{users::dsl::users, users_roles::dsl::users_roles};
+use identity::db::schema::users::dsl::users;
 use identity::db::{get_db_pool, models::*, queries};
 
 mod sample_data;
@@ -45,11 +45,6 @@ impl DbTestContext {
             .values(&sample_data::users())
             .execute(&conn)
             .expect("Error inserting 'users' sample data");
-
-        diesel::insert_into(users_roles)
-            .values(&sample_data::users_roles())
-            .execute(&conn)
-            .expect("Error inserting 'users_roles' sample data");
 
         Self {
             connection_url,
@@ -125,6 +120,7 @@ async fn db_get_user_exists() {
         oauth_access_token_valid: NaiveDate::from_ymd(2020, 12, 31).and_hms(0, 0, 0),
         oauth_refresh_token: "refresh_token".into(),
         active: true,
+        role_id: 1,
     };
 
     // Act
@@ -168,6 +164,7 @@ async fn db_get_user_by_sub() {
         oauth_access_token_valid: NaiveDate::from_ymd(2020, 12, 31).and_hms(0, 0, 0),
         oauth_refresh_token: "refresh_token".into(),
         active: true,
+        role_id: 1,
     };
 
     // Act
@@ -197,6 +194,7 @@ async fn db_list_users_exists_active() {
             oauth_access_token_valid: NaiveDate::from_ymd(2020, 12, 31).and_hms(0, 0, 0),
             oauth_refresh_token: "refresh_token".into(),
             active: true,
+            role_id: 1,
         },
         User {
             id: 5,
@@ -209,6 +207,7 @@ async fn db_list_users_exists_active() {
             oauth_access_token_valid: NaiveDate::from_ymd(2020, 12, 31).and_hms(0, 0, 0),
             oauth_refresh_token: "refresh_token".into(),
             active: true,
+            role_id: 1,
         },
     ];
 
@@ -238,6 +237,7 @@ async fn db_list_users_exists_inactive() {
         oauth_access_token_valid: NaiveDate::from_ymd(2020, 12, 31).and_hms(0, 0, 0),
         oauth_refresh_token: "refresh_token".into(),
         active: false,
+        role_id: 1,
     }];
 
     // Act
@@ -266,6 +266,7 @@ async fn db_update_user_verify() {
         oauth_access_token_valid: NaiveDate::from_ymd(2020, 12, 31).and_hms(0, 0, 0),
         oauth_refresh_token: "refresh_token".into(),
         active: false,
+        role_id: 1,
     };
 
     // Act
@@ -294,6 +295,7 @@ async fn db_update_user_by_sub_verify() {
         oauth_access_token_valid: NaiveDate::from_ymd(2020, 12, 31).and_hms(0, 0, 0),
         oauth_refresh_token: "refresh_token".into(),
         active: true,
+        role_id: 1,
     };
 
     let expected_change = UserAddUpdate {
@@ -306,6 +308,7 @@ async fn db_update_user_by_sub_verify() {
         oauth_access_token_valid: NaiveDate::from_ymd(2020, 12, 31).and_hms(0, 0, 0),
         oauth_refresh_token: None,
         active: true,
+        role_id: 1,
     };
 
     // Act
@@ -377,27 +380,6 @@ async fn list_roles_exists() {
 
     // Act
     let result = queries::list_roles(1, 2, &db_pool.get().unwrap());
-
-    // Assert
-    assert_eq!(Ok(expected_result), result);
-}
-
-// update user role
-#[tokio::test]
-async fn db_update_user_role_verify() {
-    // Arrange
-    let (_configuration, db_pool, _db_test_context) = setup(stdext::function_name!().into())
-        .await
-        .expect("Could not set up test environment");
-
-    let expected_result = UserRole {
-        id: 3,
-        user_id: 3,
-        role_id: 3,
-    };
-
-    // Act
-    let result = queries::update_user_role(expected_result.clone(), &db_pool.get().unwrap());
 
     // Assert
     assert_eq!(Ok(expected_result), result);

--- a/identity/tests/rpc_endpoints.rs
+++ b/identity/tests/rpc_endpoints.rs
@@ -8,8 +8,8 @@ use tarpc::context;
 
 use helpers::rpc::Error;
 use identity::db::get_db_pool;
-use identity::db::schema::{users::dsl::users, users_roles::dsl::users_roles};
-use identity::rpc::models::{Role, SessionInfo, User, UserRole};
+use identity::db::schema::users::dsl::users;
+use identity::rpc::models::{Role, SessionInfo, User};
 use identity::rpc::{get_rpc_client, get_rpc_server, service::IdentityServiceClient};
 use identity::{config::Configuration, session::jwt::Jwt};
 
@@ -48,11 +48,6 @@ impl DbTestContext {
             .values(&sample_data::users())
             .execute(&conn)
             .expect("Error inserting 'users' sample data");
-
-        diesel::insert_into(users_roles)
-            .values(&sample_data::users_roles())
-            .execute(&conn)
-            .expect("Error inserting 'users_roles' sample data");
 
         Self {
             connection_url,
@@ -143,6 +138,7 @@ async fn get_user_exists() {
         family_name: "Kerr".into(),
         picture: "https://example.com/avatar.jpg".into(),
         active: true,
+        role_id: 1,
     };
 
     // Act
@@ -188,6 +184,7 @@ async fn list_users_exists() {
             family_name: "Wilkins".into(),
             picture: "https://example.com/avatar.jpg".into(),
             active: true,
+            role_id: 1,
         },
         User {
             id: 5,
@@ -197,6 +194,7 @@ async fn list_users_exists() {
             family_name: "Henderson".into(),
             picture: "https://example.com/avatar.jpg".into(),
             active: true,
+            role_id: 1,
         },
     ];
 
@@ -228,6 +226,7 @@ async fn update_user_verify() {
         family_name: "Kerr".into(),
         picture: "https://example.com/avatar.jpg".into(),
         active: false,
+        role_id: 1,
     };
 
     // Act
@@ -308,32 +307,6 @@ async fn list_roles_exists() {
 
     // Act
     let result = client.list_roles(context::current(), 1, 2).await.unwrap();
-
-    // Assert
-    assert_eq!(Ok(expected_result), result);
-}
-
-// update user role
-#[tokio::test]
-async fn update_user_role_verify() {
-    // Arrange
-    let (server, mut client, _configuration, _db_test_context) =
-        setup(stdext::function_name!().into())
-            .await
-            .expect("Could not set up test environment");
-    tokio::spawn(server);
-
-    let expected_result = UserRole {
-        id: 3,
-        user_id: 3,
-        role_id: 3,
-    };
-
-    // Act
-    let result = client
-        .update_user_role(context::current(), expected_result.clone())
-        .await
-        .unwrap();
 
     // Assert
     assert_eq!(Ok(expected_result), result);

--- a/identity/tests/sample_data.rs
+++ b/identity/tests/sample_data.rs
@@ -1,6 +1,6 @@
 use chrono::NaiveDate;
 
-use identity::db::models::{UserAddUpdate, UserRoleAddUpdate};
+use identity::db::models::UserAddUpdate;
 
 pub fn users() -> Vec<UserAddUpdate> {
     vec![
@@ -14,6 +14,7 @@ pub fn users() -> Vec<UserAddUpdate> {
             oauth_access_token_valid: NaiveDate::from_ymd(2020, 12, 31).and_hms(0, 0, 0),
             oauth_refresh_token: Some("refresh_token".into()),
             active: true,
+            role_id: 1,
         },
         UserAddUpdate {
             sub: "2".into(),
@@ -25,6 +26,7 @@ pub fn users() -> Vec<UserAddUpdate> {
             oauth_access_token_valid: NaiveDate::from_ymd(2020, 12, 31).and_hms(0, 0, 0),
             oauth_refresh_token: Some("refresh_token".into()),
             active: true,
+            role_id: 1,
         },
         UserAddUpdate {
             sub: "3".into(),
@@ -36,6 +38,7 @@ pub fn users() -> Vec<UserAddUpdate> {
             oauth_access_token_valid: NaiveDate::from_ymd(2020, 12, 31).and_hms(0, 0, 0),
             oauth_refresh_token: Some("refresh_token".into()),
             active: true,
+            role_id: 1,
         },
         UserAddUpdate {
             sub: "4".into(),
@@ -47,6 +50,7 @@ pub fn users() -> Vec<UserAddUpdate> {
             oauth_access_token_valid: NaiveDate::from_ymd(2020, 12, 31).and_hms(0, 0, 0),
             oauth_refresh_token: Some("refresh_token".into()),
             active: false,
+            role_id: 1,
         },
         UserAddUpdate {
             sub: "5".into(),
@@ -58,6 +62,7 @@ pub fn users() -> Vec<UserAddUpdate> {
             oauth_access_token_valid: NaiveDate::from_ymd(2020, 12, 31).and_hms(0, 0, 0),
             oauth_refresh_token: Some("refresh_token".into()),
             active: true,
+            role_id: 1,
         },
         UserAddUpdate {
             sub: "6".into(),
@@ -69,6 +74,7 @@ pub fn users() -> Vec<UserAddUpdate> {
             oauth_access_token_valid: NaiveDate::from_ymd(2020, 12, 31).and_hms(0, 0, 0),
             oauth_refresh_token: Some("refresh_token".into()),
             active: true,
+            role_id: 1,
         },
         UserAddUpdate {
             sub: "7".into(),
@@ -80,6 +86,7 @@ pub fn users() -> Vec<UserAddUpdate> {
             oauth_access_token_valid: NaiveDate::from_ymd(2020, 12, 31).and_hms(0, 0, 0),
             oauth_refresh_token: Some("refresh_token".into()),
             active: true,
+            role_id: 1,
         },
         UserAddUpdate {
             sub: "8".into(),
@@ -91,6 +98,7 @@ pub fn users() -> Vec<UserAddUpdate> {
             oauth_access_token_valid: NaiveDate::from_ymd(2020, 12, 31).and_hms(0, 0, 0),
             oauth_refresh_token: Some("refresh_token".into()),
             active: true,
+            role_id: 1,
         },
         UserAddUpdate {
             sub: "9".into(),
@@ -102,6 +110,7 @@ pub fn users() -> Vec<UserAddUpdate> {
             oauth_access_token_valid: NaiveDate::from_ymd(2020, 12, 31).and_hms(0, 0, 0),
             oauth_refresh_token: Some("refresh_token".into()),
             active: true,
+            role_id: 1,
         },
         UserAddUpdate {
             sub: "10".into(),
@@ -113,6 +122,7 @@ pub fn users() -> Vec<UserAddUpdate> {
             oauth_access_token_valid: NaiveDate::from_ymd(2020, 12, 31).and_hms(0, 0, 0),
             oauth_refresh_token: Some("refresh_token".into()),
             active: true,
+            role_id: 1,
         },
         UserAddUpdate {
             sub: "11".into(),
@@ -124,54 +134,6 @@ pub fn users() -> Vec<UserAddUpdate> {
             oauth_access_token_valid: NaiveDate::from_ymd(2020, 12, 31).and_hms(0, 0, 0),
             oauth_refresh_token: Some("refresh_token".into()),
             active: true,
-        },
-    ]
-}
-
-pub fn users_roles() -> Vec<UserRoleAddUpdate> {
-    vec![
-        UserRoleAddUpdate {
-            user_id: 1,
-            role_id: 1,
-        },
-        UserRoleAddUpdate {
-            user_id: 2,
-            role_id: 1,
-        },
-        UserRoleAddUpdate {
-            user_id: 3,
-            role_id: 1,
-        },
-        UserRoleAddUpdate {
-            user_id: 4,
-            role_id: 1,
-        },
-        UserRoleAddUpdate {
-            user_id: 5,
-            role_id: 1,
-        },
-        UserRoleAddUpdate {
-            user_id: 6,
-            role_id: 1,
-        },
-        UserRoleAddUpdate {
-            user_id: 7,
-            role_id: 1,
-        },
-        UserRoleAddUpdate {
-            user_id: 8,
-            role_id: 2,
-        },
-        UserRoleAddUpdate {
-            user_id: 9,
-            role_id: 2,
-        },
-        UserRoleAddUpdate {
-            user_id: 10,
-            role_id: 3,
-        },
-        UserRoleAddUpdate {
-            user_id: 11,
             role_id: 1,
         },
     ]


### PR DESCRIPTION
This PR migrates the table `users_roles` and adds the user <-> role relationship as a column on the user table and is part of a few changes to simplify the service.