### PR TITLE
Feature/identity simplify roles

### DIFF
--- a/identity/migrations/2020-12-09-160000_drop_role_attributes/down.sql
+++ b/identity/migrations/2020-12-09-160000_drop_role_attributes/down.sql
@@ -1,0 +1,9 @@
+ALTER TABLE roles ADD COLUMN access_manage_books BOOLEAN;
+ALTER TABLE roles ADD COLUMN access_manage_roles BOOLEAN;
+
+UPDATE roles SET access_manage_books = false, access_manage_roles = false WHERE name = 'User';
+UPDATE roles SET access_manage_books = true, access_manage_roles = false WHERE name = 'Manager';
+UPDATE roles SET access_manage_books = true, access_manage_roles = true WHERE name = 'Administrator';
+
+ALTER TABLE roles ALTER COLUMN access_manage_books SET NOT NULL;
+ALTER TABLE roles ALTER COLUMN access_manage_roles SET NOT NULL;

--- a/identity/migrations/2020-12-09-160000_drop_role_attributes/up.sql
+++ b/identity/migrations/2020-12-09-160000_drop_role_attributes/up.sql
@@ -1,0 +1,2 @@
+ALTER TABLE roles DROP COLUMN access_manage_books;
+ALTER TABLE roles DROP COLUMN access_manage_roles;

--- a/identity/src/lib/db/models.rs
+++ b/identity/src/lib/db/models.rs
@@ -55,6 +55,4 @@ pub struct UserAddUpdate {
 pub struct Role {
     pub id: i32,
     pub name: String,
-    pub access_manage_books: bool,
-    pub access_manage_roles: bool,
 }

--- a/identity/src/lib/db/schema.rs
+++ b/identity/src/lib/db/schema.rs
@@ -2,8 +2,6 @@ table! {
     roles (id) {
         id -> Int4,
         name -> Varchar,
-        access_manage_books -> Bool,
-        access_manage_roles -> Bool,
     }
 }
 

--- a/identity/src/lib/rpc/models.rs
+++ b/identity/src/lib/rpc/models.rs
@@ -20,8 +20,6 @@ pub struct User {
 pub struct Role {
     pub id: i32,
     pub name: String,
-    pub access_manage_books: bool,
-    pub access_manage_roles: bool,
 }
 
 #[derive(Debug, Deserialize, PartialEq, Serialize)]

--- a/identity/src/lib/rpc/server.rs
+++ b/identity/src/lib/rpc/server.rs
@@ -101,8 +101,6 @@ impl IdentityService for IdentityServer {
             Ok(val) => Ok(Role {
                 id: val.id,
                 name: val.name,
-                access_manage_books: val.access_manage_books,
-                access_manage_roles: val.access_manage_roles,
             }),
             Err(diesel::result::Error::NotFound) => Err(Error::NotFound),
             Err(_) => Err(Error::InternalError),
@@ -144,8 +142,6 @@ impl IdentityService for IdentityServer {
                 .map(|x| Role {
                     id: x.id,
                     name: x.name.clone(),
-                    access_manage_books: x.access_manage_books,
-                    access_manage_roles: x.access_manage_roles,
                 })
                 .collect::<Vec<Role>>()),
             Err(diesel::result::Error::NotFound) => Err(Error::NotFound),

--- a/identity/tests/db_queries.rs
+++ b/identity/tests/db_queries.rs
@@ -329,8 +329,6 @@ async fn db_get_role_exists() {
     let expected_result = Role {
         id: 2,
         name: "Manager".into(),
-        access_manage_books: true,
-        access_manage_roles: false,
     };
 
     // Act
@@ -367,14 +365,10 @@ async fn list_roles_exists() {
         Role {
             id: 2,
             name: "Manager".into(),
-            access_manage_books: true,
-            access_manage_roles: false,
         },
         Role {
             id: 3,
             name: "Administrator".into(),
-            access_manage_books: true,
-            access_manage_roles: true,
         },
     ];
 

--- a/identity/tests/rpc_endpoints.rs
+++ b/identity/tests/rpc_endpoints.rs
@@ -252,8 +252,6 @@ async fn get_role_exists() {
     let expected_result = Role {
         id: 2,
         name: "Manager".into(),
-        access_manage_books: true,
-        access_manage_roles: false,
     };
 
     // Act
@@ -294,14 +292,10 @@ async fn list_roles_exists() {
         Role {
             id: 2,
             name: "Manager".into(),
-            access_manage_books: true,
-            access_manage_roles: false,
         },
         Role {
             id: 3,
             name: "Administrator".into(),
-            access_manage_books: true,
-            access_manage_roles: true,
         },
     ];
 


### PR DESCRIPTION
This PR removes the `manage_access-*` columns from the `roles` table as they are not used right now.