### PR TITLE
Downgrades the uuid module version to 0.7

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2017,11 +2017,11 @@ checksum = "05e42f7c18b8f902290b009cde6d651262f956c98bc51bca4cd1d511c9cd85c7"
 
 [[package]]
 name = "uuid"
-version = "0.8.1"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fde2f6a4bea1d6e007c4ad38c6839fa71cbb63b6dbf5b595aa38dc9b1093c11"
+checksum = "90dbc611eb48397705a6b0f6e917da23ae517e4d127123d2cf7674206627d32a"
 dependencies = [
- "rand 0.7.3",
+ "rand 0.6.5",
 ]
 
 [[package]]

--- a/book/Cargo.toml
+++ b/book/Cargo.toml
@@ -26,7 +26,7 @@ tokio = { version = "0.2", features = ["full"] }
 tokio-serde = { version = "0.6", features = ["json"] }
 
 [dev-dependencies]
-uuid = { version = "0.8", features = ["v4"] }
+uuid = { version = "0.7", features = ["v4"] }
 
 [features]
 test-data = []


### PR DESCRIPTION
This PR downgrades the `uuid` module, currently used in the `book` service. If diesel is used with support for UUIDs, two different versions can create conflicts and extends the compilation time a bit. We will stick to this version until the next version of Diesel supports the latest UUID module version.