### PR TITLE
Identity service - Migrate user identifiers to UUID

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -267,6 +267,7 @@ dependencies = [
  "diesel_derives",
  "pq-sys",
  "r2d2",
+ "uuid",
 ]
 
 [[package]]
@@ -714,6 +715,7 @@ dependencies = [
  "tarpc",
  "tokio",
  "tokio-serde",
+ "uuid",
 ]
 
 [[package]]
@@ -2003,6 +2005,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90dbc611eb48397705a6b0f6e917da23ae517e4d127123d2cf7674206627d32a"
 dependencies = [
  "rand 0.6.5",
+ "serde",
 ]
 
 [[package]]

--- a/identity/Cargo.toml
+++ b/identity/Cargo.toml
@@ -15,7 +15,7 @@ doc = false
 
 [dependencies]
 chrono = { version = "0.4", features = ["serde"] }
-diesel = { version = "1.4", features = [ "chrono", "postgres", "r2d2"] }
+diesel = { version = "1.4", features = ["chrono", "postgres", "r2d2", "uuidv07"] }
 diesel_migrations = "1.4"
 dotenv = "0.15"
 env_logger = "0.8"
@@ -32,3 +32,4 @@ stdext = "0.2.1"
 tarpc = { version = "0.22", features = ["full"] }
 tokio = { version = "0.2", features = ["full"] }
 tokio-serde = { version = "0.6", features = ["json"] }
+uuid = { version = "0.7", features = ["serde", "v4"] }

--- a/identity/migrations/2020-12-14-110000_migrate_uuid/down.sql
+++ b/identity/migrations/2020-12-14-110000_migrate_uuid/down.sql
@@ -1,0 +1,23 @@
+CREATE SEQUENCE users_id_seq;
+ALTER TABLE users ALTER COLUMN id SET DATA TYPE INTEGER USING nextval('users_id_seq'::regclass);
+ALTER TABLE users ALTER COLUMN id SET DEFAULT nextval('users_id_seq'::regclass);
+
+ALTER TABLE roles ADD COLUMN id_old UUID;
+UPDATE roles SET id_old = id;
+
+ALTER TABLE users DROP CONSTRAINT users_role_id_fkey;
+
+CREATE SEQUENCE roles_id_seq;
+ALTER TABLE roles ALTER COLUMN id SET DATA TYPE INTEGER USING nextval('roles_id_seq'::regclass);
+ALTER TABLE roles ALTER COLUMN id SET DEFAULT nextval('roles_id_seq'::regclass);
+
+ALTER TABLE users ADD COLUMN role_id_new INTEGER;
+
+UPDATE users SET role_id_new = (SELECT id FROM roles WHERE roles.id_old = users.role_id);
+
+ALTER TABLE roles DROP COLUMN id_old;
+ALTER TABLE roles ALTER COLUMN id SET DEFAULT nextval('roles_id_seq'::regclass);
+ALTER TABLE users DROP COLUMN role_id;
+ALTER TABLE users RENAME COLUMN role_id_new TO role_id;
+ALTER TABLE users ALTER COLUMN role_id SET NOT NULL;
+ALTER TABLE users ADD FOREIGN KEY (role_id) REFERENCES roles ON UPDATE CASCADE ON DELETE CASCADE;

--- a/identity/migrations/2020-12-14-110000_migrate_uuid/up.sql
+++ b/identity/migrations/2020-12-14-110000_migrate_uuid/up.sql
@@ -1,0 +1,19 @@
+ALTER TABLE users ALTER COLUMN id DROP DEFAULT;
+ALTER TABLE users ALTER COLUMN id SET DATA TYPE UUID USING uuid_generate_v4();
+DROP SEQUENCE users_id_seq;
+
+ALTER TABLE roles ADD COLUMN id_old INTEGER;
+UPDATE roles SET id_old = id;
+
+ALTER TABLE users ADD COLUMN role_id_new UUID;
+ALTER TABLE users DROP CONSTRAINT users_role_id_fkey;
+ALTER TABLE roles ALTER COLUMN id DROP DEFAULT;
+ALTER TABLE roles ALTER COLUMN id SET DATA TYPE UUID USING uuid_generate_v4();
+DROP SEQUENCE roles_id_seq;
+UPDATE users SET role_id_new = (SELECT id FROM roles WHERE roles.id_old = users.role_id);
+
+ALTER TABLE roles DROP COLUMN id_old;
+ALTER TABLE users DROP COLUMN role_id;
+ALTER TABLE users RENAME COLUMN role_id_new TO role_id;
+ALTER TABLE users ALTER COLUMN role_id SET NOT NULL;
+ALTER TABLE users ADD FOREIGN KEY (role_id) REFERENCES roles ON UPDATE CASCADE ON DELETE CASCADE;

--- a/identity/src/lib/authentication/mod.rs
+++ b/identity/src/lib/authentication/mod.rs
@@ -60,7 +60,7 @@ mod tests {
     #[test]
     fn check_active_account() {
         let query_result = Ok(User {
-            id: 1,
+            id: Uuid::new_v4(),
             sub: "1".into(),
             email: "john.doe@example.net".into(),
             given_name: "John".into(),
@@ -70,7 +70,7 @@ mod tests {
             oauth_access_token_valid: NaiveDate::from_ymd(2020, 12, 31).and_hms(0, 0, 0),
             oauth_refresh_token: "refresh_token".into(),
             active: true,
-            role_id: 1,
+            role_id: Uuid::new_v4(),
         });
 
         assert_eq!(
@@ -83,7 +83,7 @@ mod tests {
     #[test]
     fn check_inactive_account() {
         let query_result = Ok(User {
-            id: 1,
+            id: Uuid::new_v4(),
             sub: "1".into(),
             email: "john.doe@example.net".into(),
             given_name: "John".into(),
@@ -93,7 +93,7 @@ mod tests {
             oauth_access_token_valid: NaiveDate::from_ymd(2020, 12, 31).and_hms(0, 0, 0),
             oauth_refresh_token: "refresh_token".into(),
             active: false,
-            role_id: 1,
+            role_id: Uuid::new_v4(),
         });
 
         assert_eq!(
@@ -136,7 +136,11 @@ mod tests {
 
         let creation_time = NaiveDate::from_ymd(2020, 1, 1).and_hms(0, 0, 0);
 
+        let user_id = Uuid::new_v4();
+        let user_role_id = Uuid::new_v4();
+
         let expected_result = UserAddUpdate {
+            id: user_id,
             sub: id_token.sub.clone(),
             email: id_token.email.clone(),
             given_name: id_token.given_name.clone(),
@@ -146,10 +150,16 @@ mod tests {
             oauth_access_token_valid: NaiveDate::from_ymd(2020, 1, 1).and_hms(0, 1, 40),
             oauth_refresh_token: token_set.refresh_token.clone(),
             active: true,
-            role_id: 1,
+            role_id: user_role_id,
         };
 
-        let result = create_user_from_oauth_authentication(&id_token, &token_set, creation_time);
+        let result = create_user_from_oauth_authentication(
+            &id_token,
+            &token_set,
+            creation_time,
+            user_id,
+            user_role_id,
+        );
 
         assert_eq!(expected_result, result);
     }
@@ -180,8 +190,11 @@ mod tests {
         };
 
         let creation_time = NaiveDate::from_ymd(2020, 1, 1).and_hms(0, 0, 0);
+        let user_id = Uuid::new_v4();
+        let user_role_id = Uuid::new_v4();
 
         let expected_result = UserAddUpdate {
+            id: user_id,
             sub: id_token.sub.clone(),
             email: id_token.email.clone(),
             given_name: id_token.given_name.clone(),
@@ -191,10 +204,16 @@ mod tests {
             oauth_access_token_valid: NaiveDate::from_ymd(2020, 1, 1).and_hms(0, 1, 40),
             oauth_refresh_token: token_set.refresh_token.clone(),
             active: true,
-            role_id: 1,
+            role_id: user_role_id,
         };
 
-        let result = create_user_from_oauth_authentication(&id_token, &token_set, creation_time);
+        let result = create_user_from_oauth_authentication(
+            &id_token,
+            &token_set,
+            creation_time,
+            user_id,
+            user_role_id,
+        );
 
         assert_eq!(expected_result, result);
     }

--- a/identity/src/lib/authentication/mod.rs
+++ b/identity/src/lib/authentication/mod.rs
@@ -2,6 +2,7 @@ pub mod oauth;
 
 use chrono::{Duration, NaiveDateTime};
 use diesel::result::{Error, QueryResult};
+use uuid::Uuid;
 
 use self::oauth::{IdToken, TokenSet};
 use crate::db::models::{User, UserAddUpdate};
@@ -31,8 +32,11 @@ pub fn create_user_from_oauth_authentication(
     id_token: &IdToken,
     token_set: &TokenSet,
     creation_time: NaiveDateTime,
+    user_id: Uuid,
+    role_id: Uuid,
 ) -> UserAddUpdate {
     UserAddUpdate {
+        id: user_id,
         sub: id_token.sub.clone(),
         email: id_token.email.clone(),
         given_name: id_token.given_name.clone(),
@@ -42,7 +46,7 @@ pub fn create_user_from_oauth_authentication(
         oauth_access_token_valid: creation_time + Duration::seconds(token_set.expires_in.into()),
         oauth_refresh_token: token_set.refresh_token.clone(),
         active: true,
-        role_id: 1,
+        role_id,
     }
 }
 

--- a/identity/src/lib/db/models.rs
+++ b/identity/src/lib/db/models.rs
@@ -1,11 +1,12 @@
 use chrono::{NaiveDateTime, Utc};
+use uuid::Uuid;
 
 use super::schema::*;
 use crate::rpc::models as RpcModels;
 
 #[derive(Clone, Debug, PartialEq, Queryable)]
 pub struct User {
-    pub id: i32,
+    pub id: Uuid,
     pub sub: String,
     pub email: String,
     pub given_name: String,
@@ -15,7 +16,7 @@ pub struct User {
     pub oauth_access_token_valid: NaiveDateTime,
     pub oauth_refresh_token: String,
     pub active: bool,
-    pub role_id: i32,
+    pub role_id: Uuid,
 }
 
 impl From<RpcModels::User> for User {
@@ -39,6 +40,7 @@ impl From<RpcModels::User> for User {
 #[derive(Clone, Debug, AsChangeset, Insertable, PartialEq)]
 #[table_name = "users"]
 pub struct UserAddUpdate {
+    pub id: Uuid,
     pub sub: String,
     pub email: String,
     pub given_name: String,
@@ -48,11 +50,11 @@ pub struct UserAddUpdate {
     pub oauth_access_token_valid: NaiveDateTime,
     pub oauth_refresh_token: Option<String>,
     pub active: bool,
-    pub role_id: i32,
+    pub role_id: Uuid,
 }
 
 #[derive(Clone, Debug, PartialEq, Queryable)]
 pub struct Role {
-    pub id: i32,
+    pub id: Uuid,
     pub name: String,
 }

--- a/identity/src/lib/db/queries.rs
+++ b/identity/src/lib/db/queries.rs
@@ -1,5 +1,6 @@
 use diesel::prelude::*;
 use diesel::result::QueryResult;
+use uuid::Uuid;
 
 use super::models::*;
 use super::schema;
@@ -11,7 +12,7 @@ pub fn create_user(user: UserAddUpdate, db: &DbConn) -> QueryResult<User> {
     diesel::insert_into(users).values(&user).get_result(db)
 }
 
-pub fn get_user(user_id: i32, db: &DbConn) -> QueryResult<User> {
+pub fn get_user(user_id: Uuid, db: &DbConn) -> QueryResult<User> {
     use schema::users::dsl::users;
 
     users.find(user_id).first(db)
@@ -44,7 +45,7 @@ pub fn list_users(
 pub fn update_user(user: User, db: &DbConn) -> QueryResult<User> {
     use schema::users::dsl::*;
 
-    diesel::update(users.find(user.id as i32))
+    diesel::update(users.find(user.id))
         .set(active.eq(user.active))
         .get_result(db)
 }
@@ -57,10 +58,16 @@ pub fn update_user_by_sub(user: UserAddUpdate, db: &DbConn) -> QueryResult<User>
         .get_result(db)
 }
 
-pub fn get_role(role_id: i32, db: &DbConn) -> QueryResult<Role> {
+pub fn get_role(role_id: Uuid, db: &DbConn) -> QueryResult<Role> {
     use schema::roles::dsl::roles;
 
     roles.find(role_id).first(db)
+}
+
+pub fn get_role_by_name(role_name: &str, db: &DbConn) -> QueryResult<Role> {
+    use schema::roles::dsl::*;
+
+    roles.filter(name.eq(role_name)).get_result(db)
 }
 
 pub fn list_roles(offset: i64, limit: i64, db: &DbConn) -> QueryResult<Vec<Role>> {

--- a/identity/src/lib/db/schema.rs
+++ b/identity/src/lib/db/schema.rs
@@ -1,13 +1,13 @@
 table! {
     roles (id) {
-        id -> Int4,
+        id -> Uuid,
         name -> Varchar,
     }
 }
 
 table! {
     users (id) {
-        id -> Int4,
+        id -> Uuid,
         sub -> Varchar,
         email -> Varchar,
         given_name -> Varchar,
@@ -17,7 +17,7 @@ table! {
         oauth_access_token_valid -> Timestamp,
         oauth_refresh_token -> Varchar,
         active -> Bool,
-        role_id -> Int4,
+        role_id -> Uuid,
     }
 }
 

--- a/identity/src/lib/rpc/models.rs
+++ b/identity/src/lib/rpc/models.rs
@@ -1,4 +1,5 @@
 use serde::{Deserialize, Serialize};
+use uuid::Uuid;
 
 use crate::session::jwt::Jwt;
 
@@ -6,19 +7,19 @@ pub type OauthAuthorizationCode = String;
 
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
 pub struct User {
-    pub id: i32,
+    pub id: Uuid,
     pub sub: String,
     pub email: String,
     pub given_name: String,
     pub family_name: String,
     pub picture: String,
     pub active: bool,
-    pub role_id: i32,
+    pub role_id: Uuid,
 }
 
 #[derive(Debug, Deserialize, PartialEq, Serialize)]
 pub struct Role {
-    pub id: i32,
+    pub id: Uuid,
     pub name: String,
 }
 
@@ -34,7 +35,7 @@ pub struct SessionToken {
 
 #[derive(Debug, Deserialize, PartialEq, Serialize)]
 pub struct SessionInfo {
-    pub sub: u32,
+    pub sub: Uuid,
     pub given_name: String,
     pub family_name: String,
     pub picture: String,

--- a/identity/src/lib/rpc/service.rs
+++ b/identity/src/lib/rpc/service.rs
@@ -1,14 +1,16 @@
+use uuid::Uuid;
+
 pub use helpers::rpc::{Error, RpcResult};
 
 use super::models::*;
 
 #[tarpc::service]
 pub trait IdentityService {
-    async fn get_user(user_id: u32) -> RpcResult<User>;
+    async fn get_user(user_id: Uuid) -> RpcResult<User>;
     async fn list_users(offset: u32, limit: u32, user_active: Option<bool>)
         -> RpcResult<Vec<User>>;
     async fn update_user(user_update: User) -> RpcResult<User>;
-    async fn get_role(role_id: u32) -> RpcResult<Role>;
+    async fn get_role(role_id: Uuid) -> RpcResult<Role>;
     async fn list_roles(offset: u32, limit: u32) -> RpcResult<Vec<Role>>;
     async fn oauth_client_identifier() -> RpcResult<OauthClientIdentifier>;
     async fn oauth_authentication(code: OauthAuthorizationCode) -> RpcResult<SessionToken>;

--- a/identity/src/lib/session/jwt.rs
+++ b/identity/src/lib/session/jwt.rs
@@ -1,10 +1,11 @@
 use chrono::{DateTime, Duration, Utc};
 use jsonwebtoken::{decode, encode, DecodingKey, EncodingKey, Header, Validation};
 use serde::{Deserialize, Serialize};
+use uuid::Uuid;
 
 #[derive(Serialize, PartialEq, Debug, Deserialize)]
 pub struct Jwt {
-    pub sub: u32,
+    pub sub: Uuid,
     pub given_name: String,
     pub family_name: String,
     pub picture: String,
@@ -19,7 +20,7 @@ pub enum JwtError {
 
 impl Jwt {
     pub fn new(
-        sub: u32,
+        sub: Uuid,
         given_name: String,
         family_name: String,
         picture: String,

--- a/identity/src/lib/session/jwt.rs
+++ b/identity/src/lib/session/jwt.rs
@@ -66,10 +66,11 @@ mod tests {
 
     #[test]
     fn jwt_creation() {
+        let id = Uuid::new_v4();
         let creation_time = Utc.ymd(2020, 1, 1).and_hms(0, 0, 0);
         let validity = Duration::seconds(3600);
         let jwt = Jwt::new(
-            1,
+            id,
             "given_name".to_string(),
             "family_name".to_string(),
             "picture".to_string(),
@@ -77,7 +78,7 @@ mod tests {
             validity,
         );
 
-        assert_eq!(1, jwt.sub);
+        assert_eq!(id, jwt.sub);
         assert_eq!("given_name", jwt.given_name);
         assert_eq!("family_name", jwt.family_name);
         assert_eq!("picture", jwt.picture);
@@ -88,7 +89,7 @@ mod tests {
     #[test]
     fn jwt_encoding_decoding() {
         let jwt = Jwt::new(
-            1,
+            Uuid::new_v4(),
             "given_name".to_string(),
             "family_name".to_string(),
             "picture".to_string(),

--- a/identity/tests/sample_data.rs
+++ b/identity/tests/sample_data.rs
@@ -1,10 +1,12 @@
 use chrono::NaiveDate;
+use uuid::Uuid;
 
 use identity::db::models::UserAddUpdate;
 
-pub fn users() -> Vec<UserAddUpdate> {
+pub fn users(role_id: Uuid) -> Vec<UserAddUpdate> {
     vec![
         UserAddUpdate {
+            id: Uuid::parse_str("d1854dea-c0b7-403c-bbe8-fba377453787").unwrap(),
             sub: "1".into(),
             email: "john.doe@example.net".into(),
             given_name: "John".into(),
@@ -14,9 +16,10 @@ pub fn users() -> Vec<UserAddUpdate> {
             oauth_access_token_valid: NaiveDate::from_ymd(2020, 12, 31).and_hms(0, 0, 0),
             oauth_refresh_token: Some("refresh_token".into()),
             active: true,
-            role_id: 1,
+            role_id,
         },
         UserAddUpdate {
+            id: Uuid::parse_str("a930312e-eb70-41e4-bf74-d88bf661d4dd").unwrap(),
             sub: "2".into(),
             email: "jack.kerr@example.net".into(),
             given_name: "Jack".into(),
@@ -26,9 +29,10 @@ pub fn users() -> Vec<UserAddUpdate> {
             oauth_access_token_valid: NaiveDate::from_ymd(2020, 12, 31).and_hms(0, 0, 0),
             oauth_refresh_token: Some("refresh_token".into()),
             active: true,
-            role_id: 1,
+            role_id,
         },
         UserAddUpdate {
+            id: Uuid::parse_str("42cf1a7b-b7ca-4baf-9dfa-41f4f454a7cf").unwrap(),
             sub: "3".into(),
             email: "justin.wilkins@example.net".into(),
             given_name: "Justin".into(),
@@ -38,9 +42,10 @@ pub fn users() -> Vec<UserAddUpdate> {
             oauth_access_token_valid: NaiveDate::from_ymd(2020, 12, 31).and_hms(0, 0, 0),
             oauth_refresh_token: Some("refresh_token".into()),
             active: true,
-            role_id: 1,
+            role_id,
         },
         UserAddUpdate {
+            id: Uuid::parse_str("ad996820-085d-4b02-8a3d-10f0527a1ba0").unwrap(),
             sub: "4".into(),
             email: "tim.jackson@example.net".into(),
             given_name: "Tim".into(),
@@ -50,9 +55,10 @@ pub fn users() -> Vec<UserAddUpdate> {
             oauth_access_token_valid: NaiveDate::from_ymd(2020, 12, 31).and_hms(0, 0, 0),
             oauth_refresh_token: Some("refresh_token".into()),
             active: false,
-            role_id: 1,
+            role_id,
         },
         UserAddUpdate {
+            id: Uuid::parse_str("7cae5854-490c-4ee0-970b-8ec8a77c7c7a").unwrap(),
             sub: "5".into(),
             email: "richard.henderson@example.net".into(),
             given_name: "Richard".into(),
@@ -62,9 +68,10 @@ pub fn users() -> Vec<UserAddUpdate> {
             oauth_access_token_valid: NaiveDate::from_ymd(2020, 12, 31).and_hms(0, 0, 0),
             oauth_refresh_token: Some("refresh_token".into()),
             active: true,
-            role_id: 1,
+            role_id,
         },
         UserAddUpdate {
+            id: Uuid::parse_str("fda1f58a-34f4-41c3-9df7-e273b667a42a").unwrap(),
             sub: "6".into(),
             email: "olivia.springer@example.net".into(),
             given_name: "Olivia".into(),
@@ -74,9 +81,10 @@ pub fn users() -> Vec<UserAddUpdate> {
             oauth_access_token_valid: NaiveDate::from_ymd(2020, 12, 31).and_hms(0, 0, 0),
             oauth_refresh_token: Some("refresh_token".into()),
             active: true,
-            role_id: 1,
+            role_id,
         },
         UserAddUpdate {
+            id: Uuid::parse_str("bcdbdba5-1f6e-4660-81d7-7c198a72dd36").unwrap(),
             sub: "7".into(),
             email: "alexander.carr@example.net".into(),
             given_name: "Alexander".into(),
@@ -86,9 +94,10 @@ pub fn users() -> Vec<UserAddUpdate> {
             oauth_access_token_valid: NaiveDate::from_ymd(2020, 12, 31).and_hms(0, 0, 0),
             oauth_refresh_token: Some("refresh_token".into()),
             active: true,
-            role_id: 1,
+            role_id,
         },
         UserAddUpdate {
+            id: Uuid::parse_str("dbc9036d-c604-431c-962a-9d8c9a3346fe").unwrap(),
             sub: "8".into(),
             email: "yvonne.thomson@example.net".into(),
             given_name: "Yvonne".into(),
@@ -98,9 +107,10 @@ pub fn users() -> Vec<UserAddUpdate> {
             oauth_access_token_valid: NaiveDate::from_ymd(2020, 12, 31).and_hms(0, 0, 0),
             oauth_refresh_token: Some("refresh_token".into()),
             active: true,
-            role_id: 1,
+            role_id,
         },
         UserAddUpdate {
+            id: Uuid::parse_str("854f83cf-4181-44cb-afd6-7f9a079ca6ee").unwrap(),
             sub: "9".into(),
             email: "alan.hemmings@example.net".into(),
             given_name: "Alan".into(),
@@ -110,9 +120,10 @@ pub fn users() -> Vec<UserAddUpdate> {
             oauth_access_token_valid: NaiveDate::from_ymd(2020, 12, 31).and_hms(0, 0, 0),
             oauth_refresh_token: Some("refresh_token".into()),
             active: true,
-            role_id: 1,
+            role_id,
         },
         UserAddUpdate {
+            id: Uuid::parse_str("92b62715-8224-4ff7-a768-2270f38e68d5").unwrap(),
             sub: "10".into(),
             email: "eric.vance@example.net".into(),
             given_name: "Eric".into(),
@@ -122,9 +133,10 @@ pub fn users() -> Vec<UserAddUpdate> {
             oauth_access_token_valid: NaiveDate::from_ymd(2020, 12, 31).and_hms(0, 0, 0),
             oauth_refresh_token: Some("refresh_token".into()),
             active: true,
-            role_id: 1,
+            role_id,
         },
         UserAddUpdate {
+            id: Uuid::parse_str("167b72de-e83d-4179-925f-18e8304971cc").unwrap(),
             sub: "11".into(),
             email: "audrey.miller@example.net".into(),
             given_name: "Audrey".into(),
@@ -134,7 +146,7 @@ pub fn users() -> Vec<UserAddUpdate> {
             oauth_access_token_valid: NaiveDate::from_ymd(2020, 12, 31).and_hms(0, 0, 0),
             oauth_refresh_token: Some("refresh_token".into()),
             active: true,
-            role_id: 1,
+            role_id,
         },
     ]
 }


### PR DESCRIPTION
Adds a migration for the identity service to remove the integer ids and replace them with UUIDs. Also, changes the models and tests accordingly. This PR is part of a bigger refactoring, to also improve the database testing.