### PR TITLE
Adds automatic generation for book copy ids

### DIFF
--- a/book/migrations/20210208110427_initial_schema.down.sql
+++ b/book/migrations/20210208110427_initial_schema.down.sql
@@ -1,3 +1,7 @@
+DROP TRIGGER copies_copy_id_create_seq ON copies CASCADE;
+DROP FUNCTION copies_copy_id_create_seq;
+DROP TRIGGER copies_copy_id_delete_seq ON copies CASCADE;
+DROP FUNCTION copies_copy_id_delete_seq;
 DROP TABLE copies;
 DROP TABLE books_tags;
 DROP TABLE books_subject_areas;
@@ -11,3 +15,4 @@ DROP TABLE publishers;
 DROP TABLE persons;
 DROP TABLE languages;
 DROP TABLE categories;
+

--- a/book/src/lib/db/models.rs
+++ b/book/src/lib/db/models.rs
@@ -65,7 +65,7 @@ pub struct Editor {
 pub struct Copy {
     pub id: Uuid,
     pub book_id: Uuid,
-    pub code_identifier_copy_id: i32,
+    pub copy_id: i64,
     pub created_at: DateTime<Utc>,
     pub created_by: Uuid,
 }

--- a/book/src/lib/rpc/models.rs
+++ b/book/src/lib/rpc/models.rs
@@ -150,7 +150,7 @@ impl From<crate::db::models::Editor> for Editor {
 pub struct Copy {
     pub id: Uuid,
     pub book_id: Uuid,
-    pub code_identifier_copy_id: i32,
+    pub copy_id: i64,
     pub created_at: DateTime<Utc>,
     pub created_by: Uuid,
 }
@@ -160,7 +160,7 @@ impl From<crate::db::models::Copy> for Copy {
         Copy {
             id: copy.id,
             book_id: copy.book_id,
-            code_identifier_copy_id: copy.code_identifier_copy_id,
+            copy_id: copy.copy_id,
             created_at: copy.created_at,
             created_by: copy.created_by,
         }


### PR DESCRIPTION
* Renames field `code_identifier_copy_id` to `copy_id` on table `copies` in database migrations.
* Renames field `code_identifier_copy_id` to `copy_id` on table `copies` in database models.
* Adds database function and trigger `copies_copy_id_create_seq` to database migrations.
* Adds database function and trigger `copies_copy_id_delete_seq` to database migrations.